### PR TITLE
2.9.4: fix Autopay cancellation race, restore logging, hot-path indexes, Monero SSRF guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,11 @@ jobs:
           coverage: none
       - name: Offline Solana deep-sweep, budget and cursor tests
         run: php tests/test-sol-pagination.php
+      - name: Monero RPC URL SSRF-guard tests
+        run: php tests/test-monero-url.php
 
-  solana-retry-queue:
-    name: Solana durable retry queue (WordPress + MariaDB)
+  db-integration:
+    name: Autopay + retry queue (WordPress + WooCommerce + MariaDB)
     runs-on: ubuntu-latest
     services:
       mariadb:
@@ -118,18 +120,20 @@ jobs:
           wp config create --path=wp --dbname=wordpress --dbuser=root --dbpass=root --dbhost=127.0.0.1:3306
           wp core install --path=wp --url=http://localhost --title=CI \
             --admin_user=admin --admin_password=admin --admin_email=ci@example.com --skip-email
-      - name: Activate plugin (WooCommerce not required for this test)
+      - name: Install WooCommerce and activate the plugin
         run: |
+          wp plugin install woocommerce --activate --path=wp
           ln -s "$GITHUB_WORKSPACE/plugin" wp/wp-content/plugins/nomiddleman-crypto-payments-for-woocommerce
           wp plugin activate nomiddleman-crypto-payments-for-woocommerce --path=wp
-      - name: Run durable retry queue test (must run, not skip)
+      - name: Durable Solana retry queue test (must run, not skip)
         run: |
           OUT=$(wp eval-file "$GITHUB_WORKSPACE/plugin/tests/test-sol-retry.php" --path=wp 2>&1)
           echo "$OUT"
-          if echo "$OUT" | grep -qi "skipped"; then
-            echo "::error::retry test skipped - database not available"; exit 1
-          fi
-          if ! echo "$OUT" | grep -q "SOL-RETRY (durable queue) CHECKS PASSED"; then
-            echo "::error::retry test did not pass"; exit 1
-          fi
-          echo "durable retry queue test passed"
+          echo "$OUT" | grep -qi "skipped" && { echo "::error::retry test skipped"; exit 1; } || true
+          echo "$OUT" | grep -q "SOL-RETRY (durable queue) CHECKS PASSED" || { echo "::error::retry test did not pass"; exit 1; }
+      - name: Autopay expiry vs order-status test (must run, not skip)
+        run: |
+          OUT=$(wp eval-file "$GITHUB_WORKSPACE/plugin/tests/test-autopay-cancel.php" --path=wp 2>&1)
+          echo "$OUT"
+          echo "$OUT" | grep -qi "skipped" && { echo "::error::autopay test skipped"; exit 1; } || true
+          echo "$OUT" | grep -q "AUTOPAY-CANCEL CHECKS PASSED" || { echo "::error::autopay test did not pass"; exit 1; }

--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Requires at least: 5.0
 Tested up to: 7.0
 Requires PHP: 7.4
 License: GPL v3
-Stable Tag: 2.9.3
+Stable Tag: 2.9.4
 
 Absolutely the easiest setup in the industry. No registration. No API keys. No middleman. Accept bitcoin, ethereum, litecoin, and more.
 
@@ -182,6 +182,12 @@ Yes. Filters are available for redirecting verification requests, customizing th
 Yes - as a safeguard. Privacy Mode derives a fresh address per order from your master public key. To avoid handing out an ever-growing range of addresses, the plugin returns an address to the pool for reuse **only** if the order was abandoned without paying and fresh block-explorer checks confirm the address never received anything on-chain; any address that saw funds is retired permanently. This keeps a run of abandoned checkouts from advancing the derivation index unnecessarily. As defense-in-depth, set your receiving wallet's **gap limit** (the number of consecutive unused addresses it scans from the seed - 20 by default in Electrum) comfortably above the longest run of abandoned checkouts you would expect between payments, so a paid address is always discovered on seed recovery. In Electrum this is `wallet.change_gap_limit` / the `gap_limit_for_change` and address gap-limit settings; other HD wallets have an equivalent. This wallet setting should be a backstop, not the plugin's primary protection.
 
 == Changelog ==
+
+= 2.9.4 =
+* Autopay: the background job no longer cancels an order that was paid (by the merchant, a webhook, or the verifier) after its unpaid record was read but before cancellation - it re-checks the live order and reconciles the payment record instead. This is the Autopay counterpart of the HD-address cancellation fix in 2.9.3
+* Operational logging is restored and now routes to WooCommerce > Status > Logs (source "nomiddleman"), with error_log() as a fallback. Warnings and above (durable-queue write failures, schema-migration failures, cron-lock degradation, address-claim exhaustion, payment collisions, ...) are always recorded; verbose tracing is emitted only when debugging is enabled; repeated messages are de-duplicated and over-long entries truncated
+* Performance: added the composite database indexes the hot paths need - the 15-second customer status poll now looks up by order id, the cron's HD pool/claim/pending/assigned queries and the Autopay unpaid-address matcher use covering indexes instead of scanning as those tables grow (added to new installs and to existing ones through verified migrations)
+* Security: the merchant-configured Monero wallet RPC URL is now validated before use to prevent server-side request forgery - only http/https is allowed, redirects are not followed, the connection is protocol-restricted and pinned to the validated address, and private/loopback targets require an explicit opt-in on multisite (where site admins are not host admins)
 
 = 2.9.3 =
 * Privacy Mode (HD): payment addresses are now claimed atomically at checkout, so two customers checking out at the same moment can never be handed the same address

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -178,6 +178,31 @@ White-labeling of the admin settings page: the browser title, the wp-admin
 menu label, and the heading on the settings screen. Each receives the
 default string.
 
+### `nmm_xmr_allow_private_rpc`
+
+Whether the merchant-configured Monero wallet RPC URL may point at a private,
+loopback, or link-local address. Default: allowed on single-site (the merchant
+controls the host), blocked on multisite (site admins are not host admins). The
+`NMM_XMR_ALLOW_PRIVATE_RPC` constant sets the default; this filter can override
+per URL. Only ever loosen this for an RPC endpoint you intentionally run on a
+trusted private network.
+
+```php
+apply_filters( 'nmm_xmr_allow_private_rpc', $allowed, $url, $host, $ip );
+// or: define( 'NMM_XMR_ALLOW_PRIVATE_RPC', true );
+```
+
+### `nmm_debug_logging`
+
+Whether verbose debug/info tracing is written to the log (WooCommerce > Status >
+Logs, source `nomiddleman`). Warnings and errors are always logged regardless.
+Default follows `WP_DEBUG`; the `NMM_DEBUG_LOG` constant overrides it.
+
+```php
+apply_filters( 'nmm_debug_logging', $enabled );
+// or: define( 'NMM_DEBUG_LOG', true );
+```
+
 ## Advanced / extension hooks
 
 These exist for the legacy paid Privacy extension and are rarely useful

--- a/nomiddleman-crypto-woocommerce.php
+++ b/nomiddleman-crypto-woocommerce.php
@@ -7,7 +7,7 @@ Plugin URI:  https://wordpress.org/plugins/nomiddleman-crypto-payments-for-wooco
 Description: WooCommerce Bitcoin and Cryptocurrency Payment Gateway
 Author: nomiddleman
 Author URI: https://github.com/rmwb/nomiddleman-woocommerce
-Version: 2.9.3
+Version: 2.9.4
 Requires PHP: 7.4
 Text Domain: nomiddleman-crypto-payments-for-woocommerce
 Domain Path: /languages
@@ -71,7 +71,7 @@ function NMM_init_gateways(){
     define('NMM_PLUGIN_FILE', __FILE__);
     define('NMM_ABS_PATH', dirname(NMM_PLUGIN_FILE));
 
-    define('NMM_VERSION', '2.9.3');
+    define('NMM_VERSION', '2.9.4');
     
     define('NMM_REDUX_SLUG', 'nmmpro_options');
 
@@ -152,6 +152,7 @@ function NMM_init_gateways(){
     NMM_Register_Extensions();
     NMM_update_hd_table();
     NMM_maybe_create_sol_retry_table();
+    NMM_maybe_add_payment_indexes();
 
     add_action('init', 'NMM_schedule_payment_checks');
     add_action('admin_init', 'NMM_cleanup_legacy_qr_files');
@@ -216,6 +217,7 @@ function NMM_activate() {
     NMM_create_payment_table();
     NMM_create_carousel_table();
     NMM_maybe_create_sol_retry_table();
+    NMM_maybe_add_payment_indexes();
 }
 
 // Create/repair the durable Solana retry-queue table (gated by a schema version
@@ -232,7 +234,7 @@ function NMM_maybe_create_sol_retry_table() {
 
     $tableName = $wpdb->prefix . NMM_SOL_RETRY_TABLE;
     if ($wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $tableName)) !== $tableName) {
-        NMM_Util::log(__FILE__, __LINE__, 'Solana retry table not created (' . $wpdb->last_error . '); will retry next load.');
+        NMM_Util::log(__FILE__, __LINE__, 'Solana retry table not created (' . $wpdb->last_error . '); will retry next load.', 'error');
         return;
     }
 
@@ -278,7 +280,7 @@ function NMM_maybe_create_sol_retry_table() {
         delete_option('nmm_sol_retry_table_created'); // retire the pre-versioned flag
     }
     else {
-        NMM_Util::log(__FILE__, __LINE__, 'Solana retry schema incomplete (' . $wpdb->last_error . '); will retry next load.');
+        NMM_Util::log(__FILE__, __LINE__, 'Solana retry schema incomplete (' . $wpdb->last_error . '); will retry next load.', 'error');
     }
 }
 
@@ -392,7 +394,10 @@ function NMM_create_hd_mpk_address_table() {
             KEY `status` (`status`),
             KEY `status_checked` (`status`, `last_checked`),
             KEY `mpk_index` (`mpk_index`),
-            KEY `mpk` (`mpk`)
+            KEY `mpk` (`mpk`),
+            KEY `order_lookup` (`order_id`, `id`)
+            /* hd_mode is added by NMM_update_hd_table (1.0->1.1), so the
+               composite indexes that reference it are added there too (1.3->1.4). */
         );";
 
     $wpdb->query($query);
@@ -417,7 +422,7 @@ function NMM_update_hd_table() {
             update_option('nmm_hd_table_version', '1.1');
         }
         else {
-            NMM_Util::log(__FILE__, __LINE__, 'HD hd_mode migration did not complete (' . $wpdb->last_error . '); leaving version at 1.0 to retry.');
+            NMM_Util::log(__FILE__, __LINE__, 'HD hd_mode migration did not complete (' . $wpdb->last_error . '); leaving version at 1.0 to retry.', 'error');
         }
     }
 
@@ -450,7 +455,7 @@ function NMM_update_hd_table() {
             update_option('nmm_hd_table_version', '1.2');
         }
         else {
-            NMM_Util::log(__FILE__, __LINE__, 'HD unique-key migration did not complete (' . $wpdb->last_error . '); leaving version at 1.1 to retry.');
+            NMM_Util::log(__FILE__, __LINE__, 'HD unique-key migration did not complete (' . $wpdb->last_error . '); leaving version at 1.1 to retry.', 'error');
         }
     }
 
@@ -468,7 +473,34 @@ function NMM_update_hd_table() {
             update_option('nmm_hd_table_version', '1.3');
         }
         else {
-            NMM_Util::log(__FILE__, __LINE__, 'HD status_checked index migration did not complete (' . $wpdb->last_error . '); leaving version at 1.2 to retry.');
+            NMM_Util::log(__FILE__, __LINE__, 'HD status_checked index migration did not complete (' . $wpdb->last_error . '); leaving version at 1.2 to retry.', 'error');
+        }
+    }
+
+    // 1.3 -> 1.4: composite indexes for the hot HD queries. order_lookup serves
+    // the 15s customer status poll (WHERE order_id = ? ORDER BY id); hd_pool and
+    // hd_wallet_status serve the cron's pool/claim/pending/assigned queries that
+    // filter by cryptocurrency + hd_mode + status (and order by mpk_index or
+    // filter by mpk). These reference hd_mode, which only exists after 1.0->1.1.
+    if (get_option('nmm_hd_table_version', '1.0') === '1.3') {
+        $wanted = array(
+            'order_lookup'     => 'ADD KEY `order_lookup` (`order_id`, `id`)',
+            'hd_pool'          => 'ADD KEY `hd_pool` (`cryptocurrency`, `hd_mode`, `status`, `mpk_index`)',
+            'hd_wallet_status' => 'ADD KEY `hd_wallet_status` (`cryptocurrency`, `hd_mode`, `status`, `mpk`)',
+        );
+        $present = (array) $wpdb->get_col("SHOW INDEX FROM `$tableName`", 2);
+        foreach ($wanted as $name => $def) {
+            if (!in_array($name, $present, true)) {
+                $wpdb->query("ALTER TABLE `$tableName` $def");
+            }
+        }
+
+        $present = (array) $wpdb->get_col("SHOW INDEX FROM `$tableName`", 2);
+        if (count(array_intersect(array_keys($wanted), $present)) === count($wanted)) {
+            update_option('nmm_hd_table_version', '1.4');
+        }
+        else {
+            NMM_Util::log(__FILE__, __LINE__, 'HD composite-index migration did not complete (' . $wpdb->last_error . '); leaving version at 1.3 to retry.', 'error');
         }
     }
 
@@ -554,10 +586,47 @@ function NMM_create_payment_table() {
     
             PRIMARY KEY (`id`),
             UNIQUE KEY `unique_payment` (`order_id`, `order_amount`),
-            KEY `status` (`status`)
+            KEY `status` (`status`),
+            KEY `unpaid_address` (`status`, `cryptocurrency`, `address`),
+            KEY `unpaid_expiry` (`status`, `ordered_at`)
         );";
 
     $wpdb->query($query);
+}
+
+// Add the composite indexes the Autopay hot paths need to existing payment
+// tables (verify-then-record, like the other schema migrations). The matcher
+// queries WHERE status='unpaid' AND cryptocurrency=? AND address=?, and expiry
+// scans WHERE status='unpaid' ordered by ordered_at.
+function NMM_maybe_add_payment_indexes() {
+    if (get_option('nmm_payment_index_version') === '1') {
+        return;
+    }
+
+    global $wpdb;
+    $tableName = $wpdb->prefix . NMM_PAYMENT_TABLE;
+    if ($wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $tableName)) !== $tableName) {
+        return; // table not created yet; nothing to do
+    }
+
+    $wanted = array(
+        'unpaid_address' => 'ADD KEY `unpaid_address` (`status`, `cryptocurrency`, `address`)',
+        'unpaid_expiry'  => 'ADD KEY `unpaid_expiry` (`status`, `ordered_at`)',
+    );
+    $present = (array) $wpdb->get_col("SHOW INDEX FROM `$tableName`", 2);
+    foreach ($wanted as $name => $def) {
+        if (!in_array($name, $present, true)) {
+            $wpdb->query("ALTER TABLE `$tableName` $def");
+        }
+    }
+
+    $present = (array) $wpdb->get_col("SHOW INDEX FROM `$tableName`", 2);
+    if (count(array_intersect(array_keys($wanted), $present)) === count($wanted)) {
+        update_option('nmm_payment_index_version', '1');
+    }
+    else {
+        NMM_Util::log(__FILE__, __LINE__, 'Payment index migration did not complete (' . $wpdb->last_error . '); will retry next load.', 'error');
+    }
 }
 
 function NMM_create_carousel_table() {

--- a/src/NMM_Blockchain.php
+++ b/src/NMM_Blockchain.php
@@ -91,7 +91,7 @@ class NMM_Blockchain {
 			// 60s, 120s, 240s ... capped at 30 minutes
 			$backoff = min(60 * pow(2, $failures - 1), 30 * MINUTE_IN_SECONDS);
 			set_transient('nmm_backoff_' . md5($host), 1, $backoff);
-			NMM_Util::log(__FILE__, __LINE__, 'API host ' . $host . ' failing (http ' . $code . '), backing off ' . $backoff . 's');
+			NMM_Util::log(__FILE__, __LINE__, 'API host ' . $host . ' failing (http ' . $code . '), backing off ' . $backoff . 's', 'warning');
 		}
 		elseif ($code === 200) {
 			delete_transient('nmm_apifail_' . md5($host));
@@ -2250,7 +2250,7 @@ class NMM_Blockchain {
 				$attempts = (int) $row['attempts'] + 1;
 				NMM_Sol_Retry_Repo::reschedule($address, $sig, $attempts, $nowTs + self::sol_retry_backoff($attempts, $retryBaseSec, $retryMaxSec));
 				if ($attempts % 10 === 0) {
-					NMM_Util::log(__FILE__, __LINE__, 'Solana signature ' . $sig . ' still failing detail lookup after ' . $attempts . ' attempts (' . ($nowTs - (int) $row['first_failed_at']) . 's).');
+					NMM_Util::log(__FILE__, __LINE__, 'Solana signature ' . $sig . ' still failing detail lookup after ' . $attempts . ' attempts (' . ($nowTs - (int) $row['first_failed_at']) . 's).', 'warning');
 				}
 			}
 		}
@@ -2379,7 +2379,7 @@ class NMM_Blockchain {
 				continue;
 			}
 
-			NMM_Util::log(__FILE__, __LINE__, 'Could not durably enqueue Solana retry for ' . $entry->signature . '; holding the sweep cursor behind it so it is retried.');
+			NMM_Util::log(__FILE__, __LINE__, 'Could not durably enqueue Solana retry for ' . $entry->signature . '; holding the sweep cursor behind it so it is retried.', 'error');
 			$enqueueFailed = true;
 			break;
 		}

--- a/src/NMM_Cron.php
+++ b/src/NMM_Cron.php
@@ -29,7 +29,7 @@ function NMM_do_cron_job() {
 	// is unavailable on this host; degrade to running unlocked rather than never
 	// running, matching the pre-lock behaviour.
 	if ($lockAcquired !== '1') {
-		NMM_Util::log(__FILE__, __LINE__, 'Advisory lock unavailable on this host; running cron without overlap protection.');
+		NMM_Util::log(__FILE__, __LINE__, 'Advisory lock unavailable on this host; running cron without overlap protection.', 'warning');
 	}
 
 	try {

--- a/src/NMM_Hd_Repo.php
+++ b/src/NMM_Hd_Repo.php
@@ -139,7 +139,7 @@ class NMM_Hd_Repo {
 			// affected === 0: another request claimed this id first; retry.
 		}
 
-		NMM_Util::log(__FILE__, __LINE__, 'claim_oldest_ready exhausted retries for ' . $this->cryptoId);
+		NMM_Util::log(__FILE__, __LINE__, 'claim_oldest_ready exhausted retries for ' . $this->cryptoId, 'warning');
 		return null;
 	}
 

--- a/src/NMM_Monero.php
+++ b/src/NMM_Monero.php
@@ -83,7 +83,6 @@ class NMM_Monero {
 			curl_setopt_array($ch, $curlOpts);
 			$body = curl_exec($ch);
 			$code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-			curl_close($ch);
 
 			if ($body === false || $code !== 200) {
 				return new WP_Error('nmm_xmr', 'Monero wallet RPC unreachable (http ' . $code . ').');

--- a/src/NMM_Monero.php
+++ b/src/NMM_Monero.php
@@ -27,6 +27,11 @@ class NMM_Monero {
 			return new WP_Error('nmm_xmr', 'Monero wallet RPC is not configured.');
 		}
 
+		$target = self::validate_rpc_url($url);
+		if (is_wp_error($target)) {
+			return $target;
+		}
+
 		$payload = json_encode(array(
 			'jsonrpc' => '2.0',
 			'id' => '0',
@@ -40,15 +45,30 @@ class NMM_Monero {
 		if ($user !== '' && function_exists('curl_init')) {
 			// digest auth path
 			$ch = curl_init($url);
-			curl_setopt_array($ch, array(
+			$curlOpts = array(
 				CURLOPT_RETURNTRANSFER => true,
 				CURLOPT_TIMEOUT => 20,
+				CURLOPT_CONNECTTIMEOUT => 10,
 				CURLOPT_POST => true,
 				CURLOPT_POSTFIELDS => $payload,
 				CURLOPT_HTTPHEADER => array('Content-Type: application/json'),
 				CURLOPT_HTTPAUTH => CURLAUTH_DIGEST,
 				CURLOPT_USERPWD => $user . ':' . $pass,
-			));
+				// Restrict to HTTP(S) and never follow a redirect (which could be
+				// steered to a file:// or internal target).
+				CURLOPT_FOLLOWLOCATION => false,
+			);
+			if (defined('CURLPROTO_HTTP') && defined('CURLPROTO_HTTPS')) {
+				$curlOpts[CURLOPT_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
+				$curlOpts[CURLOPT_REDIR_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
+			}
+			// Pin the connection to the exact IP we validated, so a hostname that
+			// re-resolves to a private address between validation and connect
+			// (DNS rebinding) cannot redirect us there.
+			if (defined('CURLOPT_RESOLVE') && $target['ip'] !== '') {
+				$curlOpts[CURLOPT_RESOLVE] = array($target['host'] . ':' . $target['port'] . ':' . $target['ip']);
+			}
+			curl_setopt_array($ch, $curlOpts);
 			$body = curl_exec($ch);
 			$code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
@@ -61,6 +81,7 @@ class NMM_Monero {
 				'headers' => array('Content-Type' => 'application/json'),
 				'body' => $payload,
 				'timeout' => 20,
+				'redirection' => 0, // never follow a redirect to another target
 			));
 
 			if (is_wp_error($response) || $response['response']['code'] !== 200) {
@@ -89,6 +110,52 @@ class NMM_Monero {
 		}
 
 		return $decoded->result;
+	}
+
+	/**
+	 * Vet the merchant-configured Monero RPC URL before we request it, to stop a
+	 * settings value (a manage_options user, or a site admin on multisite who is
+	 * NOT a host admin) from steering the server at internal services, cloud
+	 * metadata, loopback, or non-HTTP schemes (SSRF). Returns an array
+	 * { host, port, ip } on success or a WP_Error to abort.
+	 *
+	 * Monero wallet RPC legitimately runs on localhost or a private LAN, so
+	 * private targets are permitted for single-site installs (the merchant owns
+	 * the server). On multisite they require an explicit opt-in - the
+	 * NMM_XMR_ALLOW_PRIVATE_RPC constant or the nmm_xmr_allow_private_rpc filter.
+	 */
+	public static function validate_rpc_url($url) {
+		$parts = wp_parse_url(trim((string) $url));
+		if (!is_array($parts) || empty($parts['scheme']) || empty($parts['host'])) {
+			return new WP_Error('nmm_xmr', 'Monero wallet RPC URL is malformed.');
+		}
+		if (!in_array(strtolower($parts['scheme']), array('http', 'https'), true)) {
+			return new WP_Error('nmm_xmr', 'Monero wallet RPC URL must use http or https.');
+		}
+
+		$host = $parts['host'];
+		$port = isset($parts['port']) ? (int) $parts['port'] : (strtolower($parts['scheme']) === 'https' ? 443 : 80);
+		$ip = filter_var($host, FILTER_VALIDATE_IP) ? $host : gethostbyname($host);
+
+		$isPrivate = (strtolower($host) === 'localhost') || self::is_private_or_reserved_ip($ip);
+		if ($isPrivate) {
+			$allow = defined('NMM_XMR_ALLOW_PRIVATE_RPC') ? (bool) NMM_XMR_ALLOW_PRIVATE_RPC : !is_multisite();
+			$allow = (bool) apply_filters('nmm_xmr_allow_private_rpc', $allow, $url, $host, $ip);
+			if (!$allow) {
+				return new WP_Error('nmm_xmr', 'Monero wallet RPC points at a private or loopback address, which is not permitted here. Define NMM_XMR_ALLOW_PRIVATE_RPC or use the nmm_xmr_allow_private_rpc filter to allow it.');
+			}
+		}
+
+		return array('host' => $host, 'port' => $port, 'ip' => filter_var($ip, FILTER_VALIDATE_IP) ? $ip : '');
+	}
+
+	// True for loopback / private / link-local (incl. 169.254.169.254 cloud
+	// metadata) / reserved addresses, and for anything that will not resolve.
+	private static function is_private_or_reserved_ip($ip) {
+		if (!filter_var($ip, FILTER_VALIDATE_IP)) {
+			return true;
+		}
+		return !filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE);
 	}
 
 	// Fresh subaddress for an order; throws so the existing checkout

--- a/src/NMM_Monero.php
+++ b/src/NMM_Monero.php
@@ -45,7 +45,11 @@ class NMM_Monero {
 		$user = $settings->get_xmr_rpc_user();
 		$pass = $settings->get_xmr_rpc_password();
 
-		$plan = self::plan_request($target, function_exists('curl_init'), $user !== '');
+		// Pinning needs both cURL and the CURLOPT_RESOLVE option; a build missing
+		// the latter has cURL but cannot pin a hostname, so treat it as unpinnable.
+		$hasCurl = function_exists('curl_init');
+		$canPin = $hasCurl && defined('CURLOPT_RESOLVE');
+		$plan = self::plan_request($target, $hasCurl, $canPin, $user !== '');
 
 		if ($plan['transport'] === 'reject') {
 			return new WP_Error('nmm_xmr', 'Monero wallet RPC host cannot be reached safely: without the cURL extension the connection cannot be pinned to the validated address, so a hostname could be rebound to a private target. Use an IP-literal RPC URL, or enable the cURL PHP extension.');
@@ -178,27 +182,33 @@ class NMM_Monero {
 	 * connection cannot be steered to a different address than the one we vetted
 	 * (DNS rebinding). Pure and side-effect free so it can be unit-tested.
 	 *
+	 * $hasCurl is whether curl_init() exists; $canPin is whether the cURL build
+	 * can actually pin a hostname to a vetted IP (curl_init AND CURLOPT_RESOLVE).
+	 * The two are distinct: an ancient libcurl without CURLOPT_RESOLVE has cURL
+	 * but cannot pin, and must not be allowed to send an unpinned hostname
+	 * request. IP literals never need pinning (there is no DNS to rebind).
+	 *
 	 * Returns array( 'transport' => 'curl'|'wp_remote'|'reject',
 	 *                'digest' => bool, 'reason' => string ).
 	 *
-	 * - curl:      cURL is available and we have a concrete IP to pin with
-	 *              CURLOPT_RESOLVE - the only transport immune to rebinding.
-	 *              Digest auth is layered on only when credentials exist.
+	 * - curl:      the host is an IP literal (safe on any cURL build), or it is a
+	 *              hostname and the build can pin it to the validated IP. The only
+	 *              rebinding-immune transport; digest auth is added only with creds.
 	 * - wp_remote: no cURL, but the host is an IP literal - there is no DNS to
 	 *              rebind, so a plain request reaches exactly the vetted address.
-	 * - reject:    no cURL and a hostname (public OR private) we cannot pin. Even
-	 *              a public host is unsafe: wp_safe_remote_post validates the name
-	 *              but re-resolves at connect time, so it could resolve publicly
-	 *              during validation and privately during the request (rebinding).
-	 *              Without CURLOPT_RESOLVE the only safe host is an IP literal, so
-	 *              we refuse any hostname rather than reopen the SSRF path.
+	 * - reject:    a hostname (public OR private) we cannot pin - no cURL, or a
+	 *              cURL build without CURLOPT_RESOLVE. Even a public host is unsafe
+	 *              because it re-resolves at connect time and could land in private
+	 *              space (rebinding), so we refuse rather than reopen the SSRF path.
 	 */
-	public static function plan_request($target, $hasCurl, $hasCreds) {
-		if ($hasCurl && $target['ip'] !== '') {
-			return array('transport' => 'curl', 'digest' => (bool) $hasCreds, 'reason' => 'pinned');
+	public static function plan_request($target, $hasCurl, $canPin, $hasCreds) {
+		$isLiteral = !empty($target['is_literal']);
+
+		if ($hasCurl && ($isLiteral || ($canPin && $target['ip'] !== ''))) {
+			return array('transport' => 'curl', 'digest' => (bool) $hasCreds, 'reason' => $isLiteral ? 'ip-literal-curl' : 'pinned');
 		}
 
-		if (!empty($target['is_literal'])) {
+		if ($isLiteral) {
 			return array('transport' => 'wp_remote', 'digest' => false, 'reason' => 'ip-literal');
 		}
 

--- a/src/NMM_Monero.php
+++ b/src/NMM_Monero.php
@@ -52,7 +52,7 @@ class NMM_Monero {
 		$plan = self::plan_request($target, $hasCurl, $canPin, $user !== '');
 
 		if ($plan['transport'] === 'reject') {
-			return new WP_Error('nmm_xmr', 'Monero wallet RPC host cannot be reached safely: without the cURL extension the connection cannot be pinned to the validated address, so a hostname could be rebound to a private target. Use an IP-literal RPC URL, or enable the cURL PHP extension.');
+			return new WP_Error('nmm_xmr', 'Monero wallet RPC host cannot be reached safely: without a pinning-capable cURL installation (the cURL extension with CURLOPT_RESOLVE) the connection cannot be pinned to the validated address, so a hostname could be rebound to a private target. Use an IP-literal RPC URL, or install a pinning-capable cURL.');
 		}
 
 		if ($plan['transport'] === 'curl') {

--- a/src/NMM_Monero.php
+++ b/src/NMM_Monero.php
@@ -48,7 +48,7 @@ class NMM_Monero {
 		$plan = self::plan_request($target, function_exists('curl_init'), $user !== '');
 
 		if ($plan['transport'] === 'reject') {
-			return new WP_Error('nmm_xmr', 'Monero wallet RPC host cannot be reached safely: it resolves to a private address but the connection cannot be pinned (no cURL). Use an IP-literal RPC URL, or enable the cURL PHP extension.');
+			return new WP_Error('nmm_xmr', 'Monero wallet RPC host cannot be reached safely: without the cURL extension the connection cannot be pinned to the validated address, so a hostname could be rebound to a private target. Use an IP-literal RPC URL, or enable the cURL PHP extension.');
 		}
 
 		if ($plan['transport'] === 'curl') {
@@ -89,19 +89,15 @@ class NMM_Monero {
 			}
 		}
 		else {
-			// No cURL. wp_safe_remote_post re-validates the resolved address and
-			// refuses private targets (public-hostname case); wp_remote_post is
-			// only chosen for IP-literal targets, where there is no DNS to rebind.
-			$args = array(
+			// No cURL: plan_request only reaches here for an IP-literal target,
+			// where there is no DNS to rebind and the request goes to exactly the
+			// address we validated. (Hostnames are rejected above.)
+			$response = wp_remote_post($url, array(
 				'headers' => array('Content-Type' => 'application/json'),
 				'body' => $payload,
 				'timeout' => 20,
 				'redirection' => 0, // never follow a redirect to another target
-			);
-
-			$response = ($plan['transport'] === 'wp_safe')
-				? wp_safe_remote_post($url, $args)
-				: wp_remote_post($url, $args);
+			));
 
 			if (is_wp_error($response) || $response['response']['code'] !== 200) {
 				return new WP_Error('nmm_xmr', 'Monero wallet RPC unreachable.');
@@ -182,7 +178,7 @@ class NMM_Monero {
 	 * connection cannot be steered to a different address than the one we vetted
 	 * (DNS rebinding). Pure and side-effect free so it can be unit-tested.
 	 *
-	 * Returns array( 'transport' => 'curl'|'wp_safe'|'wp_remote'|'reject',
+	 * Returns array( 'transport' => 'curl'|'wp_remote'|'reject',
 	 *                'digest' => bool, 'reason' => string ).
 	 *
 	 * - curl:      cURL is available and we have a concrete IP to pin with
@@ -190,11 +186,12 @@ class NMM_Monero {
 	 *              Digest auth is layered on only when credentials exist.
 	 * - wp_remote: no cURL, but the host is an IP literal - there is no DNS to
 	 *              rebind, so a plain request reaches exactly the vetted address.
-	 * - wp_safe:   no cURL and a public hostname - wp_safe_remote_post re-validates
-	 *              the resolved IP and refuses private targets at request time.
-	 * - reject:    no cURL and a private (or unresolvable) hostname we cannot pin -
-	 *              wp_safe_remote_post would block it and wp_remote_post could be
-	 *              rebound into private space, so we refuse rather than risk it.
+	 * - reject:    no cURL and a hostname (public OR private) we cannot pin. Even
+	 *              a public host is unsafe: wp_safe_remote_post validates the name
+	 *              but re-resolves at connect time, so it could resolve publicly
+	 *              during validation and privately during the request (rebinding).
+	 *              Without CURLOPT_RESOLVE the only safe host is an IP literal, so
+	 *              we refuse any hostname rather than reopen the SSRF path.
 	 */
 	public static function plan_request($target, $hasCurl, $hasCreds) {
 		if ($hasCurl && $target['ip'] !== '') {
@@ -205,11 +202,7 @@ class NMM_Monero {
 			return array('transport' => 'wp_remote', 'digest' => false, 'reason' => 'ip-literal');
 		}
 
-		if (!empty($target['is_private'])) {
-			return array('transport' => 'reject', 'digest' => false, 'reason' => 'unpinnable-private');
-		}
-
-		return array('transport' => 'wp_safe', 'digest' => false, 'reason' => 'public-hostname');
+		return array('transport' => 'reject', 'digest' => false, 'reason' => 'unpinnable-hostname');
 	}
 
 	// True for loopback / private / link-local (incl. 169.254.169.254 cloud

--- a/src/NMM_Monero.php
+++ b/src/NMM_Monero.php
@@ -78,10 +78,12 @@ class NMM_Monero {
 				$curlOpts[CURLOPT_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
 				$curlOpts[CURLOPT_REDIR_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
 			}
-			// Pin the connection to the exact IP we validated, so a hostname that
-			// re-resolves to a private address between validation and connect
-			// (DNS rebinding) cannot redirect us there.
-			if (defined('CURLOPT_RESOLVE') && $target['ip'] !== '') {
+			// Pin a hostname connection to the exact IP we validated, so a host
+			// that re-resolves to a private address between validation and connect
+			// (DNS rebinding) cannot redirect us there. IP literals are never
+			// pinned (plan_request sets pin=false): there is no DNS to rebind, and
+			// a RESOLVE entry for an IPv6 literal is malformed.
+			if ($plan['pin'] && defined('CURLOPT_RESOLVE') && $target['ip'] !== '') {
 				$curlOpts[CURLOPT_RESOLVE] = array($target['host'] . ':' . $target['port'] . ':' . $target['ip']);
 			}
 			curl_setopt_array($ch, $curlOpts);
@@ -189,7 +191,7 @@ class NMM_Monero {
 	 * request. IP literals never need pinning (there is no DNS to rebind).
 	 *
 	 * Returns array( 'transport' => 'curl'|'wp_remote'|'reject',
-	 *                'digest' => bool, 'reason' => string ).
+	 *                'digest' => bool, 'pin' => bool, 'reason' => string ).
 	 *
 	 * - curl:      the host is an IP literal (safe on any cURL build), or it is a
 	 *              hostname and the build can pin it to the validated IP. The only
@@ -200,19 +202,29 @@ class NMM_Monero {
 	 *              cURL build without CURLOPT_RESOLVE. Even a public host is unsafe
 	 *              because it re-resolves at connect time and could land in private
 	 *              space (rebinding), so we refuse rather than reopen the SSRF path.
+	 *
+	 * 'pin' is true only when the caller must attach CURLOPT_RESOLVE - i.e. a
+	 * hostname target. An IP literal is never pinned: there is no DNS to rebind,
+	 * and a RESOLVE entry for one is redundant (IPv4) or malformed (IPv6, where
+	 * the literal's own colons break the HOST:PORT:ADDRESS form).
 	 */
 	public static function plan_request($target, $hasCurl, $canPin, $hasCreds) {
 		$isLiteral = !empty($target['is_literal']);
 
 		if ($hasCurl && ($isLiteral || ($canPin && $target['ip'] !== ''))) {
-			return array('transport' => 'curl', 'digest' => (bool) $hasCreds, 'reason' => $isLiteral ? 'ip-literal-curl' : 'pinned');
+			return array(
+				'transport' => 'curl',
+				'digest' => (bool) $hasCreds,
+				'pin' => !$isLiteral,
+				'reason' => $isLiteral ? 'ip-literal-curl' : 'pinned',
+			);
 		}
 
 		if ($isLiteral) {
-			return array('transport' => 'wp_remote', 'digest' => false, 'reason' => 'ip-literal');
+			return array('transport' => 'wp_remote', 'digest' => false, 'pin' => false, 'reason' => 'ip-literal');
 		}
 
-		return array('transport' => 'reject', 'digest' => false, 'reason' => 'unpinnable-hostname');
+		return array('transport' => 'reject', 'digest' => false, 'pin' => false, 'reason' => 'unpinnable-hostname');
 	}
 
 	// True for loopback / private / link-local (incl. 169.254.169.254 cloud

--- a/src/NMM_Monero.php
+++ b/src/NMM_Monero.php
@@ -10,8 +10,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  * transfers are read over JSON-RPC - fully non-custodial, and the view key
  * never leaves the merchant's infrastructure.
  *
+ * Every request goes through validate_rpc_url() + plan_request(): when cURL is
+ * available the connection is pinned to the validated IP (CURLOPT_RESOLVE) so a
+ * hostname cannot be rebound to a private target between validation and connect.
  * monero-wallet-rpc uses HTTP digest auth when --rpc-login is set, which
- * WordPress's HTTP API does not speak; in that case we fall back to curl.
+ * WordPress's HTTP API does not speak, so digest is layered onto that cURL path.
  */
 class NMM_Monero {
 
@@ -42,8 +45,13 @@ class NMM_Monero {
 		$user = $settings->get_xmr_rpc_user();
 		$pass = $settings->get_xmr_rpc_password();
 
-		if ($user !== '' && function_exists('curl_init')) {
-			// digest auth path
+		$plan = self::plan_request($target, function_exists('curl_init'), $user !== '');
+
+		if ($plan['transport'] === 'reject') {
+			return new WP_Error('nmm_xmr', 'Monero wallet RPC host cannot be reached safely: it resolves to a private address but the connection cannot be pinned (no cURL). Use an IP-literal RPC URL, or enable the cURL PHP extension.');
+		}
+
+		if ($plan['transport'] === 'curl') {
 			$ch = curl_init($url);
 			$curlOpts = array(
 				CURLOPT_RETURNTRANSFER => true,
@@ -52,12 +60,16 @@ class NMM_Monero {
 				CURLOPT_POST => true,
 				CURLOPT_POSTFIELDS => $payload,
 				CURLOPT_HTTPHEADER => array('Content-Type: application/json'),
-				CURLOPT_HTTPAUTH => CURLAUTH_DIGEST,
-				CURLOPT_USERPWD => $user . ':' . $pass,
 				// Restrict to HTTP(S) and never follow a redirect (which could be
 				// steered to a file:// or internal target).
 				CURLOPT_FOLLOWLOCATION => false,
 			);
+			// Digest auth only when the merchant configured credentials; the RPC
+			// is otherwise open and WordPress's HTTP API cannot speak digest.
+			if ($plan['digest']) {
+				$curlOpts[CURLOPT_HTTPAUTH] = CURLAUTH_DIGEST;
+				$curlOpts[CURLOPT_USERPWD] = $user . ':' . $pass;
+			}
 			if (defined('CURLPROTO_HTTP') && defined('CURLPROTO_HTTPS')) {
 				$curlOpts[CURLOPT_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
 				$curlOpts[CURLOPT_REDIR_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
@@ -71,18 +83,26 @@ class NMM_Monero {
 			curl_setopt_array($ch, $curlOpts);
 			$body = curl_exec($ch);
 			$code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+			curl_close($ch);
 
 			if ($body === false || $code !== 200) {
 				return new WP_Error('nmm_xmr', 'Monero wallet RPC unreachable (http ' . $code . ').');
 			}
 		}
 		else {
-			$response = wp_remote_post($url, array(
+			// No cURL. wp_safe_remote_post re-validates the resolved address and
+			// refuses private targets (public-hostname case); wp_remote_post is
+			// only chosen for IP-literal targets, where there is no DNS to rebind.
+			$args = array(
 				'headers' => array('Content-Type' => 'application/json'),
 				'body' => $payload,
 				'timeout' => 20,
 				'redirection' => 0, // never follow a redirect to another target
-			));
+			);
+
+			$response = ($plan['transport'] === 'wp_safe')
+				? wp_safe_remote_post($url, $args)
+				: wp_remote_post($url, $args);
 
 			if (is_wp_error($response) || $response['response']['code'] !== 200) {
 				return new WP_Error('nmm_xmr', 'Monero wallet RPC unreachable.');
@@ -135,7 +155,8 @@ class NMM_Monero {
 
 		$host = $parts['host'];
 		$port = isset($parts['port']) ? (int) $parts['port'] : (strtolower($parts['scheme']) === 'https' ? 443 : 80);
-		$ip = filter_var($host, FILTER_VALIDATE_IP) ? $host : gethostbyname($host);
+		$isLiteral = (bool) filter_var($host, FILTER_VALIDATE_IP);
+		$ip = $isLiteral ? $host : gethostbyname($host);
 
 		$isPrivate = (strtolower($host) === 'localhost') || self::is_private_or_reserved_ip($ip);
 		if ($isPrivate) {
@@ -146,7 +167,50 @@ class NMM_Monero {
 			}
 		}
 
-		return array('host' => $host, 'port' => $port, 'ip' => filter_var($ip, FILTER_VALIDATE_IP) ? $ip : '');
+		return array(
+			'host' => $host,
+			'port' => $port,
+			'ip' => filter_var($ip, FILTER_VALIDATE_IP) ? $ip : '',
+			// is_literal: the URL host is already an IP, so there is no DNS to
+			// rebind. is_private: resolves into private/loopback/reserved space.
+			'is_literal' => $isLiteral,
+			'is_private' => $isPrivate,
+		);
+	}
+
+	/**
+	 * Decide how to send an RPC request to an already-validated target so the
+	 * connection cannot be steered to a different address than the one we vetted
+	 * (DNS rebinding). Pure and side-effect free so it can be unit-tested.
+	 *
+	 * Returns array( 'transport' => 'curl'|'wp_safe'|'wp_remote'|'reject',
+	 *                'digest' => bool, 'reason' => string ).
+	 *
+	 * - curl:      cURL is available and we have a concrete IP to pin with
+	 *              CURLOPT_RESOLVE - the only transport immune to rebinding.
+	 *              Digest auth is layered on only when credentials exist.
+	 * - wp_remote: no cURL, but the host is an IP literal - there is no DNS to
+	 *              rebind, so a plain request reaches exactly the vetted address.
+	 * - wp_safe:   no cURL and a public hostname - wp_safe_remote_post re-validates
+	 *              the resolved IP and refuses private targets at request time.
+	 * - reject:    no cURL and a private (or unresolvable) hostname we cannot pin -
+	 *              wp_safe_remote_post would block it and wp_remote_post could be
+	 *              rebound into private space, so we refuse rather than risk it.
+	 */
+	public static function plan_request($target, $hasCurl, $hasCreds) {
+		if ($hasCurl && $target['ip'] !== '') {
+			return array('transport' => 'curl', 'digest' => (bool) $hasCreds, 'reason' => 'pinned');
+		}
+
+		if (!empty($target['is_literal'])) {
+			return array('transport' => 'wp_remote', 'digest' => false, 'reason' => 'ip-literal');
+		}
+
+		if (!empty($target['is_private'])) {
+			return array('transport' => 'reject', 'digest' => false, 'reason' => 'unpinnable-private');
+		}
+
+		return array('transport' => 'wp_safe', 'digest' => false, 'reason' => 'public-hostname');
 	}
 
 	// True for loopback / private / link-local (incl. 169.254.169.254 cloud

--- a/src/NMM_Monero.php
+++ b/src/NMM_Monero.php
@@ -84,7 +84,7 @@ class NMM_Monero {
 			// pinned (plan_request sets pin=false): there is no DNS to rebind, and
 			// a RESOLVE entry for an IPv6 literal is malformed.
 			if ($plan['pin'] && defined('CURLOPT_RESOLVE') && $target['ip'] !== '') {
-				$curlOpts[CURLOPT_RESOLVE] = array($target['host'] . ':' . $target['port'] . ':' . $target['ip']);
+				$curlOpts[CURLOPT_RESOLVE] = array(self::curl_resolve_entry($target['host'], $target['port'], $target['ip']));
 			}
 			curl_setopt_array($ch, $curlOpts);
 			$body = curl_exec($ch);
@@ -155,9 +155,14 @@ class NMM_Monero {
 		}
 
 		$host = $parts['host'];
+		// parse_url keeps an IPv6 literal bracketed ("[::1]"); strip the brackets
+		// so it validates as an IP and can be pinned/vetted as a literal.
+		if (strlen($host) > 1 && $host[0] === '[' && substr($host, -1) === ']') {
+			$host = substr($host, 1, -1);
+		}
 		$port = isset($parts['port']) ? (int) $parts['port'] : (strtolower($parts['scheme']) === 'https' ? 443 : 80);
 		$isLiteral = (bool) filter_var($host, FILTER_VALIDATE_IP);
-		$ip = $isLiteral ? $host : gethostbyname($host);
+		$ip = $isLiteral ? $host : self::resolve_host($host);
 
 		$isPrivate = (strtolower($host) === 'localhost') || self::is_private_or_reserved_ip($ip);
 		if ($isPrivate) {
@@ -234,6 +239,39 @@ class NMM_Monero {
 			return true;
 		}
 		return !filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE);
+	}
+
+	// Resolve a hostname to a single IP we will pin. Prefer an A (IPv4) record;
+	// fall back to AAAA so an IPv6-only self-hosted RPC endpoint still resolves
+	// (gethostbyname() is IPv4-only and returns the host unchanged for AAAA-only
+	// names, which would otherwise be misread as unresolvable). Returns '' when
+	// nothing resolves, so the caller rejects the target rather than guessing.
+	private static function resolve_host($host) {
+		$v4 = gethostbyname($host);
+		if (filter_var($v4, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+			return $v4;
+		}
+
+		if (function_exists('dns_get_record')) {
+			$records = @dns_get_record($host, DNS_AAAA);
+			if (is_array($records)) {
+				foreach ($records as $rec) {
+					if (!empty($rec['ipv6']) && filter_var($rec['ipv6'], FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+						return $rec['ipv6'];
+					}
+				}
+			}
+		}
+
+		return '';
+	}
+
+	// Build a CURLOPT_RESOLVE entry (HOST:PORT:ADDRESS). An IPv6 address must be
+	// bracketed or its own colons make the entry ambiguous/malformed. Pure so it
+	// can be unit-tested.
+	public static function curl_resolve_entry($host, $port, $ip) {
+		$addr = (strpos($ip, ':') !== false) ? '[' . $ip . ']' : $ip;
+		return $host . ':' . (int) $port . ':' . $addr;
 	}
 
 	// Fresh subaddress for an order; throws so the existing checkout

--- a/src/NMM_Payment.php
+++ b/src/NMM_Payment.php
@@ -155,22 +155,36 @@ class NMM_Payment {
 
 				// Atomically claim the row for payment. The expiry cron races us
 				// with the opposite claim (unpaid -> cancelled); because both sides
-				// go through the same conditional update, exactly one wins. If we
-				// lose, the row was already cancelled/paid out from under us - do
-				// NOT complete the order (that would split-brain the order against
-				// its payment record).
-				if (!$paymentRepo->claim_for_payment($orderId, $orderAmount)) {
-					// Crucially, still consume the tx. This address (a static
-					// address or a carousel seat) will be reused, and an unconsumed
-					// tx that is still inside the matching window could otherwise be
+				// go through the same conditional update, exactly one wins. The
+				// claim is tri-state so we never confuse a genuine race loss with a
+				// transient DB error.
+				$claim = $paymentRepo->claim_for_payment($orderId, $orderAmount);
+
+				if ($claim === NMM_Payment_Repo::CLAIM_DB_ERROR) {
+					// The UPDATE failed, so the row state is unknown - it may well
+					// still be unpaid. Do NOT consume the tx (that would permanently
+					// ignore a valid payment) and do NOT complete the order; leave
+					// everything untouched so a later tick retries this transaction.
+					NMM_Util::log(__FILE__, __LINE__, 'Autopay: database error claiming ' . $cryptoId . ' order ' . $orderId . ' for payment; leaving the transaction unconsumed for retry. Transaction Hash: ' . $txHash, 'error');
+					continue;
+				}
+
+				if ($claim === NMM_Payment_Repo::CLAIM_ALREADY) {
+					// The row was conclusively transitioned out of 'unpaid' by
+					// another worker (expiry cron cancelled it, or another verifier
+					// paid it). Do NOT complete the order. But DO consume the tx:
+					// this address (a static address or a carousel seat) will be
+					// reused, and an unconsumed in-window tx could otherwise be
 					// matched against a *new* order of the same amount and
-					// misattribute the payment. Record the hash on the cancelled row
-					// too, for manual reconciliation.
+					// misattribute the payment. Persist the hash on the cancelled
+					// row too, for manual reconciliation.
 					$nmmSettings->add_consumed_tx($cryptoId, $address, $txHash);
 					$paymentRepo->set_hash_on_cancelled($orderId, $orderAmount, $txHash);
 					NMM_Util::log(__FILE__, __LINE__, 'Autopay: verified ' . $cryptoId . ' payment for order ' . $orderId . ' but its record was already transitioned (likely expired and cancelled) - not completing the order; recorded the transaction as consumed to prevent reuse on a recycled address. Transaction Hash: ' . $txHash . '. Please reconcile manually.', 'warning');
 					continue;
 				}
+
+				// CLAIM_CLAIMED: we won the row - complete the order.
 
 				$paymentRepo->set_hash($orderId, $orderAmount, $txHash);
 
@@ -417,10 +431,12 @@ class NMM_Payment {
 
 				// Atomically claim this row for cancellation. The verifier flips a
 				// matched row 'unpaid' -> 'paid'; this flips 'unpaid' -> 'cancelled'
-				// only while it is still 'unpaid'. If the claim affects zero rows the
-				// verifier already took the row and we must not cancel the order.
-				if (!$paymentRepo->claim_for_cancellation($orderId, $orderAmount)) {
-					NMM_Util::log(__FILE__, __LINE__, 'Autopay: cancellation claim lost for order ' . $orderId . '; another worker transitioned it first. Not cancelling.');
+				// only while it is still 'unpaid'. Only CLAIM_CLAIMED means we won
+				// and may cancel: on CLAIM_ALREADY the verifier already took the row,
+				// and on CLAIM_DB_ERROR the outcome is unknown - in both cases leave
+				// the order alone (a real error is retried next tick).
+				if ($paymentRepo->claim_for_cancellation($orderId, $orderAmount) !== NMM_Payment_Repo::CLAIM_CLAIMED) {
+					NMM_Util::log(__FILE__, __LINE__, 'Autopay: did not claim order ' . $orderId . ' for cancellation (already transitioned or DB error); not cancelling this tick.');
 					continue;
 				}
 

--- a/src/NMM_Payment.php
+++ b/src/NMM_Payment.php
@@ -25,15 +25,11 @@ class NMM_Payment {
 	}
 
 	private static function check_address_transactions_for_matching_payments($crypto, $address, $transactionLifetime) {
-		global $woocommerce;
-		$paymentRepo = new NMM_Payment_Repo();
-		$nmmSettings = new NMM_Settings(get_option(NMM_REDUX_ID));
-		
 		$cryptoId = $crypto->get_id();
 
 		NMM_Util::log(__FILE__, __LINE__, '===========================================================================');
 		NMM_Util::log(__FILE__, __LINE__, 'Starting payment verification for: ' . $cryptoId . ' - ' . $address);
-		
+
 		try {
 			$transactions = self::get_address_transactions($cryptoId, $address, $transactionLifetime);
 		}
@@ -41,9 +37,28 @@ class NMM_Payment {
 			NMM_Util::log(__FILE__, __LINE__, 'Unable to get transactions for ' . $cryptoId);
 			return;
 		}
-		
-		NMM_Util::log(__FILE__, __LINE__, 'Transcations found for ' . $cryptoId . ' - ' . $address . ': ' . print_r($transactions, true));	
 
+		NMM_Util::log(__FILE__, __LINE__, 'Transcations found for ' . $cryptoId . ' - ' . $address . ': ' . print_r($transactions, true));
+
+		self::process_address_transactions($crypto, $address, $transactions, $transactionLifetime);
+	}
+
+	/**
+	 * Match already-fetched transactions for one address against its unpaid
+	 * orders, then claim/complete or reconcile. Split out from the network fetch
+	 * so the matching, race-claim and consumed-tx logic can be exercised directly
+	 * in tests with injected NMM_Transaction objects (no external calls).
+	 *
+	 * @param NMM_Cryptocurrency $crypto
+	 * @param string             $address
+	 * @param NMM_Transaction[]  $transactions
+	 * @param int                $transactionLifetime
+	 */
+	public static function process_address_transactions($crypto, $address, $transactions, $transactionLifetime) {
+		$paymentRepo = new NMM_Payment_Repo();
+		$nmmSettings = new NMM_Settings(get_option(NMM_REDUX_ID));
+
+		$cryptoId = $crypto->get_id();
 
 		foreach ($transactions as $transaction) {
 			$txHash = $transaction->get_hash();
@@ -132,15 +147,28 @@ class NMM_Payment {
 				$orderId = $matchingPaymentRecords[0]['order_id'];
 				$orderAmount = $matchingPaymentRecords[0]['order_amount'];
 
+				// Hook fired immediately before the claim, in the exact window the
+				// conditional claim below is designed to close. Integrations - and
+				// the concurrency test - can observe or, in a race, complete/cancel
+				// the order here.
+				do_action('nmm_before_autopay_complete', $orderId, $cryptoId, $address, $txHash);
+
 				// Atomically claim the row for payment. The expiry cron races us
 				// with the opposite claim (unpaid -> cancelled); because both sides
 				// go through the same conditional update, exactly one wins. If we
 				// lose, the row was already cancelled/paid out from under us - do
 				// NOT complete the order (that would split-brain the order against
-				// its payment record). Surface a warning so a payment that arrived
-				// right at the expiry boundary can be reconciled by hand.
+				// its payment record).
 				if (!$paymentRepo->claim_for_payment($orderId, $orderAmount)) {
-					NMM_Util::log(__FILE__, __LINE__, 'Autopay: verified ' . $cryptoId . ' payment for order ' . $orderId . ' but its record was already transitioned (likely expired and cancelled) - not completing the order. Transaction Hash: ' . $txHash . '. Please reconcile manually.', 'warning');
+					// Crucially, still consume the tx. This address (a static
+					// address or a carousel seat) will be reused, and an unconsumed
+					// tx that is still inside the matching window could otherwise be
+					// matched against a *new* order of the same amount and
+					// misattribute the payment. Record the hash on the cancelled row
+					// too, for manual reconciliation.
+					$nmmSettings->add_consumed_tx($cryptoId, $address, $txHash);
+					$paymentRepo->set_hash_on_cancelled($orderId, $orderAmount, $txHash);
+					NMM_Util::log(__FILE__, __LINE__, 'Autopay: verified ' . $cryptoId . ' payment for order ' . $orderId . ' but its record was already transitioned (likely expired and cancelled) - not completing the order; recorded the transaction as consumed to prevent reuse on a recycled address. Transaction Hash: ' . $txHash . '. Please reconcile manually.', 'warning');
 					continue;
 				}
 

--- a/src/NMM_Payment.php
+++ b/src/NMM_Payment.php
@@ -66,7 +66,7 @@ class NMM_Payment {
 			}
 
 			if ($nmmSettings->tx_already_consumed($cryptoId, $address, $txHash)) {
-				NMM_Util::log(__FILE__, __LINE__, '---Collision occurred for old transaction, skipping....');
+				NMM_Util::log(__FILE__, __LINE__, '---Collision occurred for old transaction, skipping....', 'warning');
 				continue;
 			}
 
@@ -304,10 +304,36 @@ class NMM_Payment {
 				$orderId = $paymentRecord['order_id'];
 				$orderAmount = $paymentRecord['order_amount'];
 				$address = $paymentRecord['address'];
-				
-				$paymentRepo->set_status($orderId, $orderAmount, 'cancelled');
 
-				$order = new WC_Order($orderId);
+				// The unpaid rows were snapshotted earlier; re-check the live order
+				// right before touching state, because a merchant, webhook or the
+				// verifier can complete the order in between. Never cancel one that
+				// has already been paid or is no longer awaiting payment.
+				$order = $orderId ? wc_get_order($orderId) : false;
+
+				if (!$order) {
+					// Order deleted - retire the orphaned payment record without
+					// constructing a WC_Order on a bad id.
+					$paymentRepo->set_status($orderId, $orderAmount, 'cancelled');
+					NMM_Util::log(__FILE__, __LINE__, 'Autopay: order ' . $orderId . ' is gone; retiring its payment record.');
+					continue;
+				}
+
+				if ($order->is_paid()) {
+					// Paid out-of-band since the snapshot - reconcile the record to
+					// paid so the cron stops matching it, and do not cancel.
+					$paymentRepo->set_status($orderId, $orderAmount, 'paid');
+					continue;
+				}
+
+				if (!$order->has_status(array('pending', 'on-hold'))) {
+					// Terminal non-paid or otherwise not awaiting payment - reconcile
+					// the record but leave the order alone.
+					$paymentRepo->set_status($orderId, $orderAmount, 'cancelled');
+					continue;
+				}
+
+				$paymentRepo->set_status($orderId, $orderAmount, 'cancelled');
 
 				$orderNote = sprintf(
 					/* translators: 1: cryptocurrency ticker, 2: number of hours */

--- a/src/NMM_Payment.php
+++ b/src/NMM_Payment.php
@@ -66,7 +66,8 @@ class NMM_Payment {
 			}
 
 			if ($nmmSettings->tx_already_consumed($cryptoId, $address, $txHash)) {
-				NMM_Util::log(__FILE__, __LINE__, '---Collision occurred for old transaction, skipping....', 'warning');
+				// Ordinary: we have already processed this tx. Expected, not a warning.
+				NMM_Util::log(__FILE__, __LINE__, 'Already-consumed transaction skipped: ' . $txHash);
 				continue;
 			}
 
@@ -107,14 +108,23 @@ class NMM_Payment {
 			}
 			if (count($matchingPaymentRecords) > 1) {
 				// We have a collision, send admin note to each order
+				$collidingOrderIds = array();
 				foreach ($matchingPaymentRecords as $matchingRecord) {
 					$orderId = $matchingRecord['order_id'];
-					$order = new WC_Order($orderId);
+					$collidingOrderIds[] = $orderId;
+					$order = wc_get_order($orderId);
+					if (!$order) {
+						continue;
+					}
 					/* translators: 1: cryptocurrency ticker, 2: transaction hash */
 					$order->add_order_note(sprintf(__('This order has a matching %1$s transaction but we cannot verify it due to other orders with similar payment totals. Please reconcile manually. Transaction Hash: %2$s', 'nomiddleman-crypto-payments-for-woocommerce'), $cryptoId, $txHash));
 				}
-				
-				
+
+				// A genuine payment collision needs a human: surface it as a
+				// warning naming the affected orders and the tx that could not
+				// be auto-assigned. (Ordinary already-consumed skips stay debug.)
+				NMM_Util::log(__FILE__, __LINE__, 'Autopay collision: ' . $cryptoId . ' transaction ' . $txHash . ' matches multiple unpaid orders (' . implode(', ', $collidingOrderIds) . '); left for manual reconciliation.', 'warning');
+
 				$nmmSettings->add_consumed_tx($cryptoId, $address, $txHash);
 			}
 			if (count($matchingPaymentRecords) == 1) {

--- a/src/NMM_Payment.php
+++ b/src/NMM_Payment.php
@@ -130,12 +130,30 @@ class NMM_Payment {
 			if (count($matchingPaymentRecords) == 1) {
 				// We have validated a transaction: update database to paid, update order to processing, add transaction to consumed transactions
 				$orderId = $matchingPaymentRecords[0]['order_id'];
-				$orderAmount = $matchingPaymentRecords[0]['order_amount'];				
+				$orderAmount = $matchingPaymentRecords[0]['order_amount'];
 
-				$paymentRepo->set_status($orderId, $orderAmount, 'paid');
+				// Atomically claim the row for payment. The expiry cron races us
+				// with the opposite claim (unpaid -> cancelled); because both sides
+				// go through the same conditional update, exactly one wins. If we
+				// lose, the row was already cancelled/paid out from under us - do
+				// NOT complete the order (that would split-brain the order against
+				// its payment record). Surface a warning so a payment that arrived
+				// right at the expiry boundary can be reconciled by hand.
+				if (!$paymentRepo->claim_for_payment($orderId, $orderAmount)) {
+					NMM_Util::log(__FILE__, __LINE__, 'Autopay: verified ' . $cryptoId . ' payment for order ' . $orderId . ' but its record was already transitioned (likely expired and cancelled) - not completing the order. Transaction Hash: ' . $txHash . '. Please reconcile manually.', 'warning');
+					continue;
+				}
+
 				$paymentRepo->set_hash($orderId, $orderAmount, $txHash);
 
 				$order = wc_get_order($orderId);
+				if (!$order) {
+					// Row is claimed 'paid' (so it stops matching), but the order is
+					// gone - nothing to complete. Record the tx as consumed and move on.
+					NMM_Util::log(__FILE__, __LINE__, 'Autopay: verified ' . $cryptoId . ' payment but order ' . $orderId . ' no longer exists. Transaction Hash: ' . $txHash, 'warning');
+					$nmmSettings->add_consumed_tx($cryptoId, $address, $txHash);
+					continue;
+				}
 				$orderNote = sprintf(
 						/* translators: 1: amount, 2: cryptocurrency ticker, 3: date/time, 4: transaction hash */
 						__('Order payment of %1$s %2$s verified at %3$s. Transaction Hash: %4$s', 'nomiddleman-crypto-payments-for-woocommerce'),

--- a/src/NMM_Payment.php
+++ b/src/NMM_Payment.php
@@ -312,9 +312,9 @@ class NMM_Payment {
 				$order = $orderId ? wc_get_order($orderId) : false;
 
 				if (!$order) {
-					// Order deleted - retire the orphaned payment record without
-					// constructing a WC_Order on a bad id.
-					$paymentRepo->set_status($orderId, $orderAmount, 'cancelled');
+					// Order deleted - retire the orphaned payment record. Claim it
+					// conditionally so a concurrent verifier still wins the row.
+					$paymentRepo->claim_for_cancellation($orderId, $orderAmount);
 					NMM_Util::log(__FILE__, __LINE__, 'Autopay: order ' . $orderId . ' is gone; retiring its payment record.');
 					continue;
 				}
@@ -329,11 +329,45 @@ class NMM_Payment {
 				if (!$order->has_status(array('pending', 'on-hold'))) {
 					// Terminal non-paid or otherwise not awaiting payment - reconcile
 					// the record but leave the order alone.
-					$paymentRepo->set_status($orderId, $orderAmount, 'cancelled');
+					$paymentRepo->claim_for_cancellation($orderId, $orderAmount);
 					continue;
 				}
 
-				$paymentRepo->set_status($orderId, $orderAmount, 'cancelled');
+				// Atomically claim this row for cancellation. The verifier flips a
+				// matched row 'unpaid' -> 'paid'; this flips 'unpaid' -> 'cancelled'
+				// only while it is still 'unpaid'. If the claim affects zero rows the
+				// verifier already took the row and we must not cancel the order.
+				if (!$paymentRepo->claim_for_cancellation($orderId, $orderAmount)) {
+					NMM_Util::log(__FILE__, __LINE__, 'Autopay: cancellation claim lost for order ' . $orderId . '; another worker transitioned it first. Not cancelling.');
+					continue;
+				}
+
+				// Hook point immediately before the final transition. Integrations
+				// (and the concurrency test) can observe - or, in a genuine race,
+				// complete - the order here; the re-fetch below then reconciles.
+				do_action('nmm_before_autopay_cancel', $orderId, $cryptoId, $address);
+
+				// Final re-fetch after the claim to close the order-side window as
+				// far as WooCommerce allows. If the order was paid or advanced
+				// out-of-band after we claimed the row, reconcile the record and
+				// leave the order alone rather than cancelling a paid order.
+				$order = wc_get_order($orderId);
+
+				if (!$order) {
+					NMM_Util::log(__FILE__, __LINE__, 'Autopay: order ' . $orderId . ' vanished after cancellation claim; record already retired.');
+					continue;
+				}
+
+				if ($order->is_paid()) {
+					$paymentRepo->set_status($orderId, $orderAmount, 'paid');
+					NMM_Util::log(__FILE__, __LINE__, 'Autopay: order ' . $orderId . ' was paid after cancellation claim; reconciled record to paid, not cancelling.');
+					continue;
+				}
+
+				if (!$order->has_status(array('pending', 'on-hold'))) {
+					NMM_Util::log(__FILE__, __LINE__, 'Autopay: order ' . $orderId . ' advanced to ' . $order->get_status() . ' after cancellation claim; leaving order, record cancelled.');
+					continue;
+				}
 
 				$orderNote = sprintf(
 					/* translators: 1: cryptocurrency ticker, 2: number of hours */
@@ -342,8 +376,8 @@ class NMM_Payment {
 					round($paymentCancellationTimeSec/3600, 1));
 
 				add_filter('woocommerce_email_subject_customer_note', 'NMM_change_cancelled_email_note_subject_line', 1, 2);
-	    		add_filter('woocommerce_email_heading_customer_note', 'NMM_change_cancelled_email_heading', 1, 2);   
-	    		
+	    		add_filter('woocommerce_email_heading_customer_note', 'NMM_change_cancelled_email_heading', 1, 2);
+
 				$order->update_status('wc-cancelled');
 				$order->add_order_note($orderNote, true);
 

--- a/src/NMM_Payment.php
+++ b/src/NMM_Payment.php
@@ -299,15 +299,41 @@ class NMM_Payment {
 		$nmmSettings = new NMM_Settings(get_option(NMM_REDUX_ID));
 
 		$paymentRepo = new NMM_Payment_Repo();
-		$unpaidPayments = $paymentRepo->get_unpaid();
+
+		// Single clock for the whole pass, shared by the coarse SQL cutoff below
+		// and the exact per-record check, so the two can never disagree by a
+		// second at a boundary.
+		$now = time();
+
+		// Only rows old enough to be expirable for SOME configured coin can
+		// possibly be cancelled. The shortest cancellation window among the coins
+		// that actually have unpaid rows is a safe coarse cutoff: anything newer
+		// than it is within every window and cannot be expired. Filtering on it in
+		// SQL lets the unpaid_expiry(status, ordered_at) index do a range scan
+		// instead of returning every unpaid checkout for PHP to iterate.
+		$unpaidCryptos = $paymentRepo->get_distinct_unpaid_cryptos();
+		if (empty($unpaidCryptos)) {
+			return;
+		}
+
+		$shortestWindowSec = null;
+		foreach ($unpaidCryptos as $unpaidCryptoId) {
+			$windowSec = (float) $nmmSettings->get_autopay_cancellation_time($unpaidCryptoId) * 60 * 60;
+			if ($shortestWindowSec === null || $windowSec < $shortestWindowSec) {
+				$shortestWindowSec = $windowSec;
+			}
+		}
+
+		$coarseCutoff = $now - $shortestWindowSec;
+		$unpaidPayments = $paymentRepo->get_unpaid($coarseCutoff);
 
 		foreach ($unpaidPayments as $paymentRecord) {
 			$orderTime = $paymentRecord['ordered_at'];
-			$cryptoId = $paymentRecord['cryptocurrency'];			
+			$cryptoId = $paymentRecord['cryptocurrency'];
 
 			$paymentCancellationTimeHr = $nmmSettings->get_autopay_cancellation_time($cryptoId);
 			$paymentCancellationTimeSec = $paymentCancellationTimeHr * 60 * 60;
-			$timeSinceOrder = time() - $orderTime;
+			$timeSinceOrder = $now - $orderTime;
 			NMM_Util::log(__FILE__, __LINE__, 'cryptoID: ' . $cryptoId . ' payment cancellation time sec: ' . $paymentCancellationTimeSec . ' time since order: ' . $timeSinceOrder);
 
 			if ($timeSinceOrder > $paymentCancellationTimeSec) {

--- a/src/NMM_Payment_Repo.php
+++ b/src/NMM_Payment_Repo.php
@@ -106,31 +106,44 @@ class NMM_Payment_Repo {
 	}
 
 	/**
-	 * Atomically claim an unpaid payment row for cancellation. Flips the row to
-	 * 'cancelled' only WHERE it is still 'unpaid', so the expiry cron and the
-	 * payment verifier (which flips 'unpaid' -> 'paid') cannot both act on the
-	 * same row. Returns true only if this call was the one that transitioned the
-	 * row; false if another worker already moved it out of 'unpaid' (or on a DB
-	 * error, which is logged), in which case the caller must not cancel the order.
+	 * Atomically transition a payment row out of 'unpaid' to $toStatus, only
+	 * WHERE it is still 'unpaid'. The expiry cron (unpaid -> cancelled) and the
+	 * payment verifier (unpaid -> paid) race for the same row; because BOTH go
+	 * through this conditional update, exactly one wins and the loser sees zero
+	 * affected rows and must not apply its side effect (cancel the order, or
+	 * complete it). Returns true only if this call was the one that moved the
+	 * row; false if another worker already moved it, or on a logged DB error.
 	 */
-	public function claim_for_cancellation($orderId, $orderAmount) {
+	private function claim_from_unpaid($orderId, $orderAmount, $toStatus) {
 		global $wpdb;
 
 		$affected = $wpdb->query($wpdb->prepare(
 			"UPDATE `$this->tableName`
-			 SET `status` = 'cancelled'
+			 SET `status` = %s
 			 WHERE `order_amount` = %s
 			 AND `order_id` = %d
 			 AND `status` = 'unpaid'",
-			$orderAmount, $orderId
+			$toStatus, $orderAmount, $orderId
 		));
 
 		if ($affected === false) {
-			NMM_Util::log(__FILE__, __LINE__, 'claim_for_cancellation DB error for order ' . $orderId . ': ' . $wpdb->last_error, 'error');
+			NMM_Util::log(__FILE__, __LINE__, 'claim to ' . $toStatus . ' DB error for order ' . $orderId . ': ' . $wpdb->last_error, 'error');
 			return false;
 		}
 
 		return $affected > 0;
+	}
+
+	// Expiry cron's side of the race: claim the row for cancellation.
+	public function claim_for_cancellation($orderId, $orderAmount) {
+		return $this->claim_from_unpaid($orderId, $orderAmount, 'cancelled');
+	}
+
+	// Verifier's side of the race: claim the row for payment. If this returns
+	// false the row was already cancelled/paid by another worker and the caller
+	// must NOT complete the order.
+	public function claim_for_payment($orderId, $orderAmount) {
+		return $this->claim_from_unpaid($orderId, $orderAmount, 'paid');
 	}
 
 	public function set_hash($orderId, $orderAmount, $hash) {

--- a/src/NMM_Payment_Repo.php
+++ b/src/NMM_Payment_Repo.php
@@ -158,6 +158,26 @@ class NMM_Payment_Repo {
 		));
 	}
 
+	/**
+	 * Record the received tx hash on a row we could not complete because the
+	 * expiry race cancelled it, for manual reconciliation. Scoped to a genuinely
+	 * cancelled row that has no hash yet, so it can never clobber the hash of a
+	 * row that a concurrent verifier legitimately marked paid.
+	 */
+	public function set_hash_on_cancelled($orderId, $orderAmount, $hash) {
+		global $wpdb;
+
+		$wpdb->query($wpdb->prepare(
+			"UPDATE `$this->tableName`
+			 SET `tx_hash` = %s
+			 WHERE `order_amount` = %s
+			 AND `order_id` = %d
+			 AND `status` = 'cancelled'
+			 AND (`tx_hash` IS NULL OR `tx_hash` = '')",
+			$hash, $orderAmount, $orderId
+		));
+	}
+
 	public function set_ordered_at($orderId, $orderAmount, $orderedAt) {
 		global $wpdb;
 

--- a/src/NMM_Payment_Repo.php
+++ b/src/NMM_Payment_Repo.php
@@ -25,21 +25,42 @@ class NMM_Payment_Repo {
 		));
 	}
 
-	public function get_unpaid() {
+	/**
+	 * Unpaid payment rows. When $orderedBefore is given (a unix timestamp), only
+	 * rows older than it are returned: WHERE status='unpaid' AND ordered_at < cutoff,
+	 * which the unpaid_expiry(status, ordered_at) index serves as a range scan so
+	 * the expiry cron never has to transfer and iterate every recent unpaid
+	 * checkout. Passing null keeps the old "every unpaid row" behaviour.
+	 */
+	public function get_unpaid($orderedBefore = null) {
 		global $wpdb;
 
-		$query = "SELECT `address`,
-						 `cryptocurrency`,
-						 `order_id`,
-						 `order_amount`,
-						 `status`,
-						 `ordered_at`
-				  FROM `$this->tableName`
-				  WHERE `status` = 'unpaid'";
+		$select = "SELECT `address`,
+						  `cryptocurrency`,
+						  `order_id`,
+						  `order_amount`,
+						  `status`,
+						  `ordered_at`
+				   FROM `$this->tableName`
+				   WHERE `status` = 'unpaid'";
 
-		$results = $wpdb->get_results($query, ARRAY_A);
+		if ($orderedBefore === null) {
+			return $wpdb->get_results($select, ARRAY_A);
+		}
 
-		return $results;
+		return $wpdb->get_results($wpdb->prepare(
+			$select . " AND `ordered_at` < %d",
+			(int) $orderedBefore
+		), ARRAY_A);
+	}
+
+	// Distinct cryptocurrencies among the unpaid rows. Cheap (index-only on the
+	// status prefix, few distinct values) and lets the expiry cron compute the
+	// shortest cancellation window it must consider before querying.
+	public function get_distinct_unpaid_cryptos() {
+		global $wpdb;
+
+		return $wpdb->get_col("SELECT DISTINCT `cryptocurrency` FROM `$this->tableName` WHERE `status` = 'unpaid'");
 	}
 
 	public function get_distinct_unpaid_addresses() {

--- a/src/NMM_Payment_Repo.php
+++ b/src/NMM_Payment_Repo.php
@@ -84,6 +84,34 @@ class NMM_Payment_Repo {
 		));
 	}
 
+	/**
+	 * Atomically claim an unpaid payment row for cancellation. Flips the row to
+	 * 'cancelled' only WHERE it is still 'unpaid', so the expiry cron and the
+	 * payment verifier (which flips 'unpaid' -> 'paid') cannot both act on the
+	 * same row. Returns true only if this call was the one that transitioned the
+	 * row; false if another worker already moved it out of 'unpaid' (or on a DB
+	 * error, which is logged), in which case the caller must not cancel the order.
+	 */
+	public function claim_for_cancellation($orderId, $orderAmount) {
+		global $wpdb;
+
+		$affected = $wpdb->query($wpdb->prepare(
+			"UPDATE `$this->tableName`
+			 SET `status` = 'cancelled'
+			 WHERE `order_amount` = %s
+			 AND `order_id` = %d
+			 AND `status` = 'unpaid'",
+			$orderAmount, $orderId
+		));
+
+		if ($affected === false) {
+			NMM_Util::log(__FILE__, __LINE__, 'claim_for_cancellation DB error for order ' . $orderId . ': ' . $wpdb->last_error, 'error');
+			return false;
+		}
+
+		return $affected > 0;
+	}
+
 	public function set_hash($orderId, $orderAmount, $hash) {
 		global $wpdb;
 

--- a/src/NMM_Payment_Repo.php
+++ b/src/NMM_Payment_Repo.php
@@ -105,14 +105,23 @@ class NMM_Payment_Repo {
 		));
 	}
 
+	// Tri-state result of a conditional claim. CLAIMED: this call moved the row.
+	// ALREADY: the row was conclusively transitioned out of 'unpaid' by another
+	// worker (cancelled or paid) - a definite, retry-free outcome. DB_ERROR: the
+	// UPDATE failed, so the row state is UNKNOWN (it may well still be unpaid) and
+	// the caller must not treat it as settled - retry next tick.
+	const CLAIM_CLAIMED = 'claimed';
+	const CLAIM_ALREADY = 'already';
+	const CLAIM_DB_ERROR = 'db_error';
+
 	/**
 	 * Atomically transition a payment row out of 'unpaid' to $toStatus, only
 	 * WHERE it is still 'unpaid'. The expiry cron (unpaid -> cancelled) and the
 	 * payment verifier (unpaid -> paid) race for the same row; because BOTH go
-	 * through this conditional update, exactly one wins and the loser sees zero
-	 * affected rows and must not apply its side effect (cancel the order, or
-	 * complete it). Returns true only if this call was the one that moved the
-	 * row; false if another worker already moved it, or on a logged DB error.
+	 * through this conditional update, exactly one wins. Returns a tri-state so a
+	 * genuine race loss (CLAIM_ALREADY) is never confused with a transient
+	 * database failure (CLAIM_DB_ERROR): the former is conclusive, the latter
+	 * must be retried rather than treated as settled.
 	 */
 	private function claim_from_unpaid($orderId, $orderAmount, $toStatus) {
 		global $wpdb;
@@ -128,20 +137,22 @@ class NMM_Payment_Repo {
 
 		if ($affected === false) {
 			NMM_Util::log(__FILE__, __LINE__, 'claim to ' . $toStatus . ' DB error for order ' . $orderId . ': ' . $wpdb->last_error, 'error');
-			return false;
+			return self::CLAIM_DB_ERROR;
 		}
 
-		return $affected > 0;
+		return $affected > 0 ? self::CLAIM_CLAIMED : self::CLAIM_ALREADY;
 	}
 
-	// Expiry cron's side of the race: claim the row for cancellation.
+	// Expiry cron's side of the race: claim the row for cancellation. Returns one
+	// of the CLAIM_* constants.
 	public function claim_for_cancellation($orderId, $orderAmount) {
 		return $this->claim_from_unpaid($orderId, $orderAmount, 'cancelled');
 	}
 
-	// Verifier's side of the race: claim the row for payment. If this returns
-	// false the row was already cancelled/paid by another worker and the caller
-	// must NOT complete the order.
+	// Verifier's side of the race: claim the row for payment. Returns one of the
+	// CLAIM_* constants; only CLAIM_CLAIMED means this caller may complete the
+	// order. On CLAIM_ALREADY the row was cancelled/paid elsewhere; on
+	// CLAIM_DB_ERROR the outcome is unknown and must be retried.
 	public function claim_for_payment($orderId, $orderAmount) {
 		return $this->claim_from_unpaid($orderId, $orderAmount, 'paid');
 	}

--- a/src/NMM_Sol_Retry_Repo.php
+++ b/src/NMM_Sol_Retry_Repo.php
@@ -63,7 +63,7 @@ class NMM_Sol_Retry_Repo {
 			$address, $signature, $now, $now, (int) $blockTime
 		));
 		if ($result === false) {
-			NMM_Util::log(__FILE__, __LINE__, 'Solana retry enqueue failed for ' . $signature . ': ' . $wpdb->last_error);
+			NMM_Util::log(__FILE__, __LINE__, 'Solana retry enqueue failed for ' . $signature . ': ' . $wpdb->last_error, 'error');
 			return false;
 		}
 		return true;
@@ -81,7 +81,7 @@ class NMM_Sol_Retry_Repo {
 			$attempts, $nextRetryAt, $address, $signature
 		));
 		if ($result === false) {
-			NMM_Util::log(__FILE__, __LINE__, 'Solana retry reschedule failed for ' . $signature . ': ' . $wpdb->last_error);
+			NMM_Util::log(__FILE__, __LINE__, 'Solana retry reschedule failed for ' . $signature . ': ' . $wpdb->last_error, 'error');
 			return false;
 		}
 		return true;
@@ -99,7 +99,7 @@ class NMM_Sol_Retry_Repo {
 			$address, $signature
 		));
 		if ($result === false) {
-			NMM_Util::log(__FILE__, __LINE__, 'Solana retry remove failed for ' . $signature . ': ' . $wpdb->last_error);
+			NMM_Util::log(__FILE__, __LINE__, 'Solana retry remove failed for ' . $signature . ': ' . $wpdb->last_error, 'error');
 			return false;
 		}
 		return true;
@@ -127,7 +127,7 @@ class NMM_Sol_Retry_Repo {
 			$address, (int) $windowCutoffBlockTime, (int) $limit
 		));
 		if ($byBlock === false) {
-			NMM_Util::log(__FILE__, __LINE__, 'Solana retry block-time expiry failed for ' . $address . ': ' . $wpdb->last_error);
+			NMM_Util::log(__FILE__, __LINE__, 'Solana retry block-time expiry failed for ' . $address . ': ' . $wpdb->last_error, 'error');
 			return -1;
 		}
 
@@ -136,7 +136,7 @@ class NMM_Sol_Retry_Repo {
 			$address, (int) $retentionCutoffFirstFailed, (int) $limit
 		));
 		if ($byRetention === false) {
-			NMM_Util::log(__FILE__, __LINE__, 'Solana retry retention expiry failed for ' . $address . ': ' . $wpdb->last_error);
+			NMM_Util::log(__FILE__, __LINE__, 'Solana retry retention expiry failed for ' . $address . ': ' . $wpdb->last_error, 'error');
 			return -1;
 		}
 
@@ -160,7 +160,7 @@ class NMM_Sol_Retry_Repo {
 			(int) $cutoffFirstFailed, (int) $limit
 		));
 		if ($result === false) {
-			NMM_Util::log(__FILE__, __LINE__, 'Solana retry global cleanup failed: ' . $wpdb->last_error);
+			NMM_Util::log(__FILE__, __LINE__, 'Solana retry global cleanup failed: ' . $wpdb->last_error, 'error');
 			return -1;
 		}
 		return (int) $result;

--- a/src/NMM_Util.php
+++ b/src/NMM_Util.php
@@ -6,25 +6,57 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class NMM_Util {
 
-	public static function log($fileName, $lineNumber, $message) {
-		
-		// $logFileName = dirname(__DIR__) . '/' . NMM_LOGFILE_NAME;
-		
-		// if (file_exists($logFileName)) {
-		// 	$file = fopen($logFileName, 'r+');
-		// 	if ($file) {
-		// 		fseek($file, 0, SEEK_END);
-		// 	}
-		// }
-		// else
-		// {
-		// 	$file = fopen($logFileName, 'w');
-		// }
+	/**
+	 * Operational log. Routes to WooCommerce's logger (WooCommerce > Status >
+	 * Logs, source "nomiddleman") when available, otherwise error_log().
+	 *
+	 * Levels follow WC_Log_Levels. Warnings and above are always emitted so an
+	 * operator sees events that may need intervention (enqueue/migration
+	 * failures, cron-lock degradation, address-claim exhaustion, payment
+	 * collisions, ...). Verbose debug/info tracing is emitted only when debug
+	 * logging is enabled (WP_DEBUG, the NMM_DEBUG_LOG constant, or the
+	 * nmm_debug_logging filter), so production is not flooded. Identical
+	 * messages are de-duplicated for a short window so a per-tick failure can
+	 * be visible without spamming, and messages are length-capped so a full
+	 * third-party response is never dumped wholesale.
+	 */
+	public static function log($fileName, $lineNumber, $message, $level = 'debug') {
+		$important = in_array($level, array('warning', 'error', 'critical', 'alert', 'emergency'), true);
 
-		// if ($file) {
-		// 	fwrite($file, "\r\n" . date("m-d-Y, G:i:s T") . "$fileName - $lineNumber: " . $message);
-		// 	fclose($file);
-		// }
+		if (!$important && !self::debug_logging_enabled()) {
+			return;
+		}
+
+		$message = (string) $message;
+		if (strlen($message) > 2000) {
+			$message = substr($message, 0, 2000) . ' ...[truncated]';
+		}
+		$entry = basename((string) $fileName) . ':' . $lineNumber . '  ' . $message;
+
+		// De-duplicate: skip an identical entry seen within the throttle window.
+		if (function_exists('get_transient') && function_exists('set_transient')) {
+			$throttleKey = 'nmm_log_' . md5($level . '|' . $entry);
+			if (get_transient($throttleKey) !== false) {
+				return;
+			}
+			$window = in_array($level, array('error', 'critical', 'alert', 'emergency'), true) ? 60 : 300;
+			set_transient($throttleKey, 1, $window);
+		}
+
+		if (function_exists('wc_get_logger')) {
+			wc_get_logger()->log($level, $entry, array('source' => 'nomiddleman'));
+		}
+		else {
+			error_log('[nomiddleman][' . $level . '] ' . $entry);
+		}
+	}
+
+	private static function debug_logging_enabled() {
+		if (defined('NMM_DEBUG_LOG')) {
+			return (bool) NMM_DEBUG_LOG;
+		}
+		$default = defined('WP_DEBUG') && WP_DEBUG;
+		return function_exists('apply_filters') ? (bool) apply_filters('nmm_debug_logging', $default) : $default;
 	}
 
 	public static function p_enabled() {

--- a/tests/test-autopay-cancel.php
+++ b/tests/test-autopay-cancel.php
@@ -101,7 +101,7 @@ $wpdb->query("DELETE FROM `$pt`");
 $oClaimed = mkorder('pending'); $ins($oClaimed, $expired);
 $wpdb->query($wpdb->prepare("UPDATE `$pt` SET status='paid' WHERE order_id=%d", $oClaimed));
 $repo = new NMM_Payment_Repo();
-aok('claim on already-paid row returns false',  $repo->claim_for_cancellation($oClaimed, '0.00100000') === false);
+aok('claim on already-paid row -> CLAIM_ALREADY', $repo->claim_for_cancellation($oClaimed, '0.00100000') === NMM_Payment_Repo::CLAIM_ALREADY);
 NMM_Payment::cancel_expired_payments(); // no unpaid rows -> order stays pending
 aok('order left pending (claim lost)',          ord_status($oClaimed) === 'pending');
 aok('  record still paid, not cancelled',       rec_status($wpdb,$pt,$oClaimed) === 'paid');
@@ -112,16 +112,25 @@ aok('  record still paid, not cancelled',       rec_status($wpdb,$pt,$oClaimed) 
 $wpdb->query("DELETE FROM `$pt`");
 $oRow = mkorder('pending'); $ins($oRow, $expired);
 $rp = new NMM_Payment_Repo();
-aok('verifier claim_for_payment wins unpaid row', $rp->claim_for_payment($oRow, '0.00100000') === true);
+aok('verifier claim_for_payment -> CLAIM_CLAIMED', $rp->claim_for_payment($oRow, '0.00100000') === NMM_Payment_Repo::CLAIM_CLAIMED);
 aok('  row is now paid',                          rec_status($wpdb,$pt,$oRow) === 'paid');
-aok('cron claim then loses (row not unpaid)',     $rp->claim_for_cancellation($oRow, '0.00100000') === false);
+aok('cron claim then loses -> CLAIM_ALREADY',     $rp->claim_for_cancellation($oRow, '0.00100000') === NMM_Payment_Repo::CLAIM_ALREADY);
+
+// A transient DB failure must be distinguishable from a race loss (CLAIM_DB_ERROR
+// != CLAIM_ALREADY), so the caller can retry instead of burning the payment.
+$wpdb->query("RENAME TABLE `$pt` TO `{$pt}_bak`");
+$wpdb->suppress_errors(true);
+$claimErr = $rp->claim_for_payment($oRow, '0.00100000'); // table missing -> UPDATE fails
+$wpdb->suppress_errors(false);
+$wpdb->query("RENAME TABLE `{$pt}_bak` TO `$pt`");
+aok('claim on DB error -> CLAIM_DB_ERROR',        $claimErr === NMM_Payment_Repo::CLAIM_DB_ERROR, 'got=' . $claimErr);
 
 // Opposite order: cron wins first, verifier must lose and would abort completion.
 $wpdb->query("DELETE FROM `$pt`");
 $oRow2 = mkorder('pending'); $ins($oRow2, $expired);
-aok('cron claim_for_cancellation wins unpaid row', $rp->claim_for_cancellation($oRow2, '0.00100000') === true);
+aok('cron claim_for_cancellation -> CLAIM_CLAIMED', $rp->claim_for_cancellation($oRow2, '0.00100000') === NMM_Payment_Repo::CLAIM_CLAIMED);
 aok('  row is now cancelled',                      rec_status($wpdb,$pt,$oRow2) === 'cancelled');
-aok('verifier then loses (row not unpaid)',        $rp->claim_for_payment($oRow2, '0.00100000') === false);
+aok('verifier then loses -> CLAIM_ALREADY',        $rp->claim_for_payment($oRow2, '0.00100000') === NMM_Payment_Repo::CLAIM_ALREADY);
 
 // --- Index: the expiry query must range-scan unpaid_expiry, not read every row ---
 // Seed a realistic distribution - many recent unpaid checkouts, a few old ones -
@@ -204,10 +213,36 @@ NMM_Payment::process_address_transactions($btc, $reuseAddr, array($tx), $lifetim
 aok('reused address: new order B NOT paid',     rec_status($wpdb,$pt,$oB) === 'unpaid');
 aok('reused address: order B still pending',    ord_status($oB) === 'pending');
 
+// End-to-end: a DB error during the payment claim must NOT consume the tx.
+// The hook renames the table away right before the claim, forcing the UPDATE to
+// fail (CLAIM_DB_ERROR). The row is still unpaid, so the verified tx must be left
+// unconsumed and the order untouched, ready to retry - otherwise a transient
+// glitch would permanently strand a real payment.
+$wpdb->query($wpdb->prepare("DELETE FROM `$pt` WHERE address=%s", $reuseAddr));
+delete_option('nmmpro_BTC_transactions_consumed_for_' . $reuseAddr);
+$oErr = mkorder('pending');
+$wpdb->query($wpdb->prepare(
+	"INSERT INTO `$pt` (address,cryptocurrency,status,ordered_at,order_id,order_amount,hd_address) VALUES (%s,'BTC','unpaid',%d,%d,%s,0)",
+	$reuseAddr, time(), $oErr, $reuseAmt));
+$txErr = new NMM_Transaction($txUnits, 999, time(), 'TXDBERRe2e');
+$errHook = function($orderId, $cryptoId, $address, $hash) use ($oErr, $pt, $wpdb) {
+	if ($orderId == $oErr) { $wpdb->suppress_errors(true); $wpdb->query("RENAME TABLE `$pt` TO `{$pt}_bak`"); }
+};
+add_action('nmm_before_autopay_complete', $errHook, 10, 4);
+NMM_Payment::process_address_transactions($btc, $reuseAddr, array($txErr), $lifetime);
+remove_action('nmm_before_autopay_complete', $errHook, 10);
+$wpdb->query("RENAME TABLE `{$pt}_bak` TO `$pt`"); // restore; row is still unpaid
+$wpdb->suppress_errors(false);
+
+aok('DB error: tx left UNconsumed (retryable)', $stg->tx_already_consumed('BTC', $reuseAddr, 'TXDBERRe2e') === false);
+aok('DB error: record still unpaid',            rec_status($wpdb,$pt,$oErr) === 'unpaid');
+aok('DB error: order still pending',            ord_status($oErr) === 'pending');
+
 // Sanity: a fresh, unconsumed tx on the reused address DOES complete a new order.
 // Clear the address's rows first so only order C is unpaid on it (order B lingers
 // unpaid by design, which would otherwise make C an ambiguous collision).
 $wpdb->query($wpdb->prepare("DELETE FROM `$pt` WHERE address=%s", $reuseAddr));
+delete_option('nmmpro_BTC_transactions_consumed_for_' . $reuseAddr);
 $oC = mkorder('pending');
 $wpdb->query($wpdb->prepare(
 	"INSERT INTO `$pt` (address,cryptocurrency,status,ordered_at,order_id,order_amount,hd_address) VALUES (%s,'BTC','unpaid',%d,%d,%s,0)",

--- a/tests/test-autopay-cancel.php
+++ b/tests/test-autopay-cancel.php
@@ -67,5 +67,40 @@ aok('  its record cancelled',                  rec_status($wpdb,$pt,$oExpPending
 aok('expired on-hold order cancelled',         ord_status($oExpOnHold) === 'cancelled');
 aok('  its record cancelled',                  rec_status($wpdb,$pt,$oExpOnHold) === 'cancelled');
 
+// --- Concurrency: order completes AFTER the claim, right before cancellation ---
+// The nmm_before_autopay_cancel hook fires immediately after the row is claimed
+// and before the final re-fetch. Completing the order there simulates a merchant
+// or verifier winning the race in that window; the re-fetch must catch it and
+// reconcile to paid instead of cancelling a now-paid order.
+$wpdb->query("DELETE FROM `$pt`");
+$oRace = mkorder('pending'); $ins($oRace, $expired);
+$raceFired = 0;
+$raceHook = function($orderId, $cryptoId, $address) use ($oRace, &$raceFired) {
+	if ($orderId != $oRace) { return; }
+	$raceFired++;
+	$o = wc_get_order($orderId);   // complete the order mid-transition
+	$o->payment_complete();
+	$o->save();
+};
+add_action('nmm_before_autopay_cancel', $raceHook, 10, 3);
+NMM_Payment::cancel_expired_payments();
+remove_action('nmm_before_autopay_cancel', $raceHook, 10);
+
+aok('race hook fired for claimed order',        $raceFired === 1, 'fired=' . $raceFired);
+aok('order paid mid-transition NOT cancelled',  ord_status($oRace) !== 'cancelled', 'status=' . ord_status($oRace));
+aok('  its record reconciled to paid',          rec_status($wpdb,$pt,$oRace) === 'paid');
+
+// --- Conditional claim: a row already moved out of 'unpaid' is not re-cancelled ---
+// Simulates the verifier having flipped the row to 'paid' before the cron runs;
+// claim_for_cancellation must report zero rows and the order must be left alone.
+$wpdb->query("DELETE FROM `$pt`");
+$oClaimed = mkorder('pending'); $ins($oClaimed, $expired);
+$wpdb->query($wpdb->prepare("UPDATE `$pt` SET status='paid' WHERE order_id=%d", $oClaimed));
+$repo = new NMM_Payment_Repo();
+aok('claim on already-paid row returns false',  $repo->claim_for_cancellation($oClaimed, '0.00100000') === false);
+NMM_Payment::cancel_expired_payments(); // no unpaid rows -> order stays pending
+aok('order left pending (claim lost)',          ord_status($oClaimed) === 'pending');
+aok('  record still paid, not cancelled',       rec_status($wpdb,$pt,$oClaimed) === 'paid');
+
 $wpdb->query("DELETE FROM `$pt`");
 echo $pass ? "\nAUTOPAY-CANCEL CHECKS PASSED\n" : "\nAUTOPAY-CANCEL CHECKS FAILED\n";

--- a/tests/test-autopay-cancel.php
+++ b/tests/test-autopay-cancel.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Live-DB test: NMM_Payment::cancel_expired_payments() must never cancel an
+ * order that has been paid or is no longer awaiting payment (the legacy Autopay
+ * analogue of the HD cancellation race). Requires WordPress + WooCommerce + a
+ * database. Skips cleanly standalone.
+ *
+ *   Run:  wp eval-file tests/test-autopay-cancel.php
+ */
+
+if (!isset($GLOBALS['wpdb']) || !is_object($GLOBALS['wpdb']) || !function_exists('wc_create_order')) {
+	echo "test-autopay-cancel: skipped (needs WordPress + WooCommerce + DB)\n";
+	return;
+}
+
+$wpdb = $GLOBALS['wpdb'];
+$pt = $wpdb->prefix . NMM_PAYMENT_TABLE;
+$wpdb->query("DELETE FROM `$pt`");
+
+$pass = true;
+function aok($label, $cond, $extra = '') { global $pass; printf("%-52s %s%s\n", $label, $cond ? 'ok' : 'FAIL', $extra !== '' ? "  $extra" : ''); if (!$cond) { $pass = false; } }
+
+$crypto = 'BTC';                 // default autopay cancellation window is 24h
+$expired = time() - (25 * 3600); // past the window
+$fresh   = time();               // within the window
+
+function mkorder($status) { $o = wc_create_order(); $o->set_payment_method('nmmpro_gateway'); $o->set_status($status); $o->save(); return $o->get_id(); }
+$ins = function($orderId, $orderedAt) use ($wpdb, $pt, $crypto) {
+	$wpdb->query($wpdb->prepare(
+		"INSERT INTO `$pt` (address,cryptocurrency,status,ordered_at,order_id,order_amount,hd_address)
+		 VALUES ('addr_$orderId',%s,'unpaid',%d,%d,'0.00100000',0)",
+		$crypto, $orderedAt, $orderId));
+};
+function rec_status($wpdb, $pt, $orderId) { return $wpdb->get_var($wpdb->prepare("SELECT status FROM `$pt` WHERE order_id=%d", $orderId)); }
+function ord_status($orderId) { $o = wc_get_order($orderId); return $o ? $o->get_status() : '(gone)'; }
+
+$oProcessing = mkorder('processing'); $ins($oProcessing, $expired); // paid
+$oCompleted  = mkorder('completed');  $ins($oCompleted,  $expired); // paid
+$oCancelled  = mkorder('cancelled');  $ins($oCancelled,  $expired); // terminal non-paid
+$ins(950001, $expired);                                             // deleted order (no WC_Order)
+$oFresh      = mkorder('pending');     $ins($oFresh, $fresh);        // not expired yet
+$oExpPending = mkorder('pending');     $ins($oExpPending, $expired); // expired, awaiting payment
+$oExpOnHold  = mkorder('on-hold');     $ins($oExpOnHold, $expired);  // expired, awaiting payment
+
+NMM_Payment::cancel_expired_payments();
+
+// Paid orders: never cancelled; record reconciled to paid.
+aok('paid (processing) order NOT cancelled',   ord_status($oProcessing) === 'processing');
+aok('  its payment record reconciled to paid', rec_status($wpdb,$pt,$oProcessing) === 'paid');
+aok('paid (completed) order NOT cancelled',    ord_status($oCompleted) === 'completed');
+aok('  its payment record reconciled to paid', rec_status($wpdb,$pt,$oCompleted) === 'paid');
+
+// Terminal non-paid: left alone, record reconciled to cancelled.
+aok('already-cancelled order left cancelled',  ord_status($oCancelled) === 'cancelled');
+aok('  its record reconciled to cancelled',    rec_status($wpdb,$pt,$oCancelled) === 'cancelled');
+
+// Deleted order: record retired without a fatal.
+aok('deleted order record retired (cancelled)', rec_status($wpdb,$pt,950001) === 'cancelled');
+
+// Fresh pending: untouched.
+aok('fresh (unexpired) order untouched',       ord_status($oFresh) === 'pending');
+aok('  its record still unpaid',               rec_status($wpdb,$pt,$oFresh) === 'unpaid');
+
+// Expired + awaiting payment: cancelled.
+aok('expired pending order cancelled',         ord_status($oExpPending) === 'cancelled');
+aok('  its record cancelled',                  rec_status($wpdb,$pt,$oExpPending) === 'cancelled');
+aok('expired on-hold order cancelled',         ord_status($oExpOnHold) === 'cancelled');
+aok('  its record cancelled',                  rec_status($wpdb,$pt,$oExpOnHold) === 'cancelled');
+
+$wpdb->query("DELETE FROM `$pt`");
+echo $pass ? "\nAUTOPAY-CANCEL CHECKS PASSED\n" : "\nAUTOPAY-CANCEL CHECKS FAILED\n";

--- a/tests/test-autopay-cancel.php
+++ b/tests/test-autopay-cancel.php
@@ -17,8 +17,12 @@ $wpdb = $GLOBALS['wpdb'];
 $pt = $wpdb->prefix . NMM_PAYMENT_TABLE;
 $wpdb->query("DELETE FROM `$pt`");
 
-$pass = true;
-function aok($label, $cond, $extra = '') { global $pass; printf("%-52s %s%s\n", $label, $cond ? 'ok' : 'FAIL', $extra !== '' ? "  $extra" : ''); if (!$cond) { $pass = false; } }
+// NOTE: wp eval-file runs this file in function scope, so a plain top-level
+// `$pass` is NOT the same variable a `global $pass` inside aok() would write.
+// Track pass/fail through $GLOBALS explicitly so the final banner is accurate
+// (otherwise a failing check could still print PASSED and slip through CI).
+$GLOBALS['ac_ok'] = true;
+function aok($label, $cond, $extra = '') { printf("%-52s %s%s\n", $label, $cond ? 'ok' : 'FAIL', $extra !== '' ? "  $extra" : ''); if (!$cond) { $GLOBALS['ac_ok'] = false; } }
 
 $crypto = 'BTC';                 // default autopay cancellation window is 24h
 $expired = time() - (25 * 3600); // past the window
@@ -151,5 +155,66 @@ $repo2 = new NMM_Payment_Repo();
 aok('cutoff returns only the 12 expired rows', count($repo2->get_unpaid($cutoff)) === 12, 'got=' . count($repo2->get_unpaid($cutoff)));
 aok('no-cutoff still returns all 412 rows',    count($repo2->get_unpaid()) === 412, 'got=' . count($repo2->get_unpaid()));
 
+// --- End-to-end: cancellation wins the race, reused address must not re-match ---
+// Drive the real matcher with an injected in-window transaction. A hook fires in
+// the exact pre-claim window and simulates the expiry cron winning (unpaid ->
+// cancelled), so the verifier's claim loses. The verified tx MUST still be
+// consumed, or the same still-in-window tx could later complete a *new* order on
+// the reused static/carousel address (payment misattribution).
 $wpdb->query("DELETE FROM `$pt`");
-echo $pass ? "\nAUTOPAY-CANCEL CHECKS PASSED\n" : "\nAUTOPAY-CANCEL CHECKS FAILED\n";
+$cryptos = NMM_Cryptocurrencies::get();
+$btc = $cryptos['BTC'];
+$reuseAddr = 'addr_reuse_e2e';
+$reuseAmt  = '0.00100000';
+$txHash    = 'TXREUSEe2e';
+$lifetime  = 3600;
+$txUnits   = $reuseAmt * (10 ** $btc->get_round_precision()); // smallest-unit amount
+$tx = new NMM_Transaction($txUnits, 999 /*confirmations*/, time() /*in window*/, $txHash);
+$rpe = new NMM_Payment_Repo();
+$stg = new NMM_Settings(get_option(NMM_REDUX_ID));
+// Consumed-tx state lives in a per-address option that outlives the table wipe;
+// clear it so this test is deterministic across repeated runs.
+delete_option('nmmpro_BTC_transactions_consumed_for_' . $reuseAddr);
+
+// Order A on the reused address, unpaid.
+$oA = mkorder('pending');
+$wpdb->query($wpdb->prepare(
+	"INSERT INTO `$pt` (address,cryptocurrency,status,ordered_at,order_id,order_amount,hd_address) VALUES (%s,'BTC','unpaid',%d,%d,%s,0)",
+	$reuseAddr, time(), $oA, $reuseAmt));
+
+$loseHook = function($orderId, $cryptoId, $address, $hash) use ($oA, $reuseAmt, $rpe) {
+	if ($orderId == $oA) { $rpe->claim_for_cancellation($oA, $reuseAmt); } // cron wins the row
+};
+add_action('nmm_before_autopay_complete', $loseHook, 10, 4);
+NMM_Payment::process_address_transactions($btc, $reuseAddr, array($tx), $lifetime);
+remove_action('nmm_before_autopay_complete', $loseHook, 10);
+
+aok('lost race: order A record cancelled',      rec_status($wpdb,$pt,$oA) === 'cancelled');
+aok('lost race: order A not completed',         !wc_get_order($oA)->has_status(array('processing','completed')), 'status=' . ord_status($oA));
+aok('lost race: tx recorded as consumed',       $stg->tx_already_consumed('BTC', $reuseAddr, $txHash) === true);
+aok('lost race: hash persisted on cancelled row', $wpdb->get_var($wpdb->prepare("SELECT tx_hash FROM `$pt` WHERE order_id=%d", $oA)) === $txHash);
+
+// Reuse the address for a NEW order B, same amount; the same tx must be skipped.
+$oB = mkorder('pending');
+$wpdb->query($wpdb->prepare(
+	"INSERT INTO `$pt` (address,cryptocurrency,status,ordered_at,order_id,order_amount,hd_address) VALUES (%s,'BTC','unpaid',%d,%d,%s,0)",
+	$reuseAddr, time(), $oB, $reuseAmt));
+NMM_Payment::process_address_transactions($btc, $reuseAddr, array($tx), $lifetime);
+
+aok('reused address: new order B NOT paid',     rec_status($wpdb,$pt,$oB) === 'unpaid');
+aok('reused address: order B still pending',    ord_status($oB) === 'pending');
+
+// Sanity: a fresh, unconsumed tx on the reused address DOES complete a new order.
+// Clear the address's rows first so only order C is unpaid on it (order B lingers
+// unpaid by design, which would otherwise make C an ambiguous collision).
+$wpdb->query($wpdb->prepare("DELETE FROM `$pt` WHERE address=%s", $reuseAddr));
+$oC = mkorder('pending');
+$wpdb->query($wpdb->prepare(
+	"INSERT INTO `$pt` (address,cryptocurrency,status,ordered_at,order_id,order_amount,hd_address) VALUES (%s,'BTC','unpaid',%d,%d,%s,0)",
+	$reuseAddr, time(), $oC, $reuseAmt));
+$tx2 = new NMM_Transaction($txUnits, 999, time(), 'TXFRESHe2e');
+NMM_Payment::process_address_transactions($btc, $reuseAddr, array($tx2), $lifetime);
+aok('control: fresh tx DOES pay a new order',   rec_status($wpdb,$pt,$oC) === 'paid');
+
+$wpdb->query("DELETE FROM `$pt`");
+echo $GLOBALS['ac_ok'] ? "\nAUTOPAY-CANCEL CHECKS PASSED\n" : "\nAUTOPAY-CANCEL CHECKS FAILED\n";

--- a/tests/test-autopay-cancel.php
+++ b/tests/test-autopay-cancel.php
@@ -102,6 +102,23 @@ NMM_Payment::cancel_expired_payments(); // no unpaid rows -> order stays pending
 aok('order left pending (claim lost)',          ord_status($oClaimed) === 'pending');
 aok('  record still paid, not cancelled',       rec_status($wpdb,$pt,$oClaimed) === 'paid');
 
+// --- Mutual exclusion: both sides of the race use the same conditional claim ---
+// The verifier's claim_for_payment and the cron's claim_for_cancellation both
+// transition only WHERE status='unpaid'. Exactly one can win a given row.
+$wpdb->query("DELETE FROM `$pt`");
+$oRow = mkorder('pending'); $ins($oRow, $expired);
+$rp = new NMM_Payment_Repo();
+aok('verifier claim_for_payment wins unpaid row', $rp->claim_for_payment($oRow, '0.00100000') === true);
+aok('  row is now paid',                          rec_status($wpdb,$pt,$oRow) === 'paid');
+aok('cron claim then loses (row not unpaid)',     $rp->claim_for_cancellation($oRow, '0.00100000') === false);
+
+// Opposite order: cron wins first, verifier must lose and would abort completion.
+$wpdb->query("DELETE FROM `$pt`");
+$oRow2 = mkorder('pending'); $ins($oRow2, $expired);
+aok('cron claim_for_cancellation wins unpaid row', $rp->claim_for_cancellation($oRow2, '0.00100000') === true);
+aok('  row is now cancelled',                      rec_status($wpdb,$pt,$oRow2) === 'cancelled');
+aok('verifier then loses (row not unpaid)',        $rp->claim_for_payment($oRow2, '0.00100000') === false);
+
 // --- Index: the expiry query must range-scan unpaid_expiry, not read every row ---
 // Seed a realistic distribution - many recent unpaid checkouts, a few old ones -
 // and assert the exact production query (WHERE status='unpaid' AND ordered_at <

--- a/tests/test-autopay-cancel.php
+++ b/tests/test-autopay-cancel.php
@@ -102,5 +102,37 @@ NMM_Payment::cancel_expired_payments(); // no unpaid rows -> order stays pending
 aok('order left pending (claim lost)',          ord_status($oClaimed) === 'pending');
 aok('  record still paid, not cancelled',       rec_status($wpdb,$pt,$oClaimed) === 'paid');
 
+// --- Index: the expiry query must range-scan unpaid_expiry, not read every row ---
+// Seed a realistic distribution - many recent unpaid checkouts, a few old ones -
+// and assert the exact production query (WHERE status='unpaid' AND ordered_at <
+// cutoff) uses the unpaid_expiry(status, ordered_at) index rather than scanning
+// all unpaid rows. This is what the coarse cutoff in cancel_expired_payments()
+// buys: O(expired) transferred to PHP, not O(all unpaid).
+$wpdb->query("DELETE FROM `$pt`");
+$now = time();
+$fresh24 = $now - (1 * 3600);    // within the 24h BTC window
+$old48   = $now - (48 * 3600);   // past it
+$rows = array();
+for ($i = 0; $i < 400; $i++) { $rows[] = $wpdb->prepare("('addr_f_%d','BTC','unpaid',%d,%d,'0.00100000',0)", $i, $fresh24, 800000 + $i); }
+for ($i = 0; $i < 12;  $i++) { $rows[] = $wpdb->prepare("('addr_o_%d','BTC','unpaid',%d,%d,'0.00100000',0)", $i, $old48,  900000 + $i); }
+$wpdb->query("INSERT INTO `$pt` (address,cryptocurrency,status,ordered_at,order_id,order_amount,hd_address) VALUES " . implode(',', $rows));
+$wpdb->query("ANALYZE TABLE `$pt`");
+
+$cutoff = $now - (24 * 3600);
+$explainQuery = "SELECT `address`,`cryptocurrency`,`order_id`,`order_amount`,`status`,`ordered_at` FROM `$pt` WHERE `status` = 'unpaid' AND `ordered_at` < " . (int) $cutoff;
+$plan = $wpdb->get_results("EXPLAIN $explainQuery", ARRAY_A);
+$planKey  = isset($plan[0]['key'])  ? $plan[0]['key']  : '(none)';
+$planType = isset($plan[0]['type']) ? $plan[0]['type'] : '(none)';
+$planRows = isset($plan[0]['rows']) ? (int) $plan[0]['rows'] : -1;
+
+aok('expiry query uses unpaid_expiry index',   $planKey === 'unpaid_expiry', 'key=' . $planKey);
+aok('  as a range scan',                       $planType === 'range', 'type=' . $planType);
+aok('  examines far fewer than 412 rows',      $planRows > 0 && $planRows <= 100, 'rows=' . $planRows);
+
+// And the cutoff query itself returns only the old rows (correctness of the filter).
+$repo2 = new NMM_Payment_Repo();
+aok('cutoff returns only the 12 expired rows', count($repo2->get_unpaid($cutoff)) === 12, 'got=' . count($repo2->get_unpaid($cutoff)));
+aok('no-cutoff still returns all 412 rows',    count($repo2->get_unpaid()) === 412, 'got=' . count($repo2->get_unpaid()));
+
 $wpdb->query("DELETE FROM `$pt`");
 echo $pass ? "\nAUTOPAY-CANCEL CHECKS PASSED\n" : "\nAUTOPAY-CANCEL CHECKS FAILED\n";

--- a/tests/test-monero-url.php
+++ b/tests/test-monero-url.php
@@ -67,6 +67,7 @@ $publicHost     = array('host' => 'wallet.example.com','port' => 443,   'ip' => 
 $privateLiteral = array('host' => '127.0.0.1',         'port' => 18082, 'ip' => '127.0.0.1',     'is_literal' => true,  'is_private' => true);
 $privateHost    = array('host' => 'localhost',         'port' => 18082, 'ip' => '127.0.0.1',     'is_literal' => false, 'is_private' => true);
 $unresolvable   = array('host' => 'nope.invalid',      'port' => 80,    'ip' => '',              'is_literal' => false, 'is_private' => true);
+$ipv6Literal    = array('host' => '::1',               'port' => 18082, 'ip' => '::1',           'is_literal' => true,  'is_private' => true);
 
 // cURL that can pin: pin every host, public or private.
 mok('curl pins public literal',      plan($publicLiteral, true, true, false)['transport'] === 'curl');
@@ -74,6 +75,14 @@ mok('curl pins public hostname',     plan($publicHost,    true, true, false)['tr
 mok('curl pins private hostname',    plan($privateHost,   true, true, false)['transport'] === 'curl');
 mok('curl digest off without creds', plan($publicLiteral, true, true, false)['digest'] === false);
 mok('curl digest on with creds',     plan($publicLiteral, true, true, true)['digest']  === true);
+
+// pin flag: only a hostname is pinned with CURLOPT_RESOLVE. IP literals must not
+// be pinned - redundant for IPv4, and a malformed RESOLVE entry for IPv6.
+mok('pin set for hostname',          plan($publicHost,    true, true, false)['pin'] === true);
+mok('pin NOT set for ipv4 literal',  plan($publicLiteral, true, true, false)['pin'] === false);
+mok('pin NOT set for ipv6 literal',  plan($ipv6Literal,   true, true, false)['pin'] === false);
+mok('ipv6 literal still uses curl',  plan($ipv6Literal,   true, true, false)['transport'] === 'curl');
+mok('pin NOT set on wp_remote path', plan($publicLiteral, false, false, false)['pin'] === false);
 
 // cURL present but the build CANNOT pin (no CURLOPT_RESOLVE): a hostname must be
 // refused (it would send unpinned), while an IP literal is still safe over cURL

--- a/tests/test-monero-url.php
+++ b/tests/test-monero-url.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Offline test for NMM_Monero::validate_rpc_url() - the SSRF guard on the
+ * merchant-configured Monero wallet RPC URL. Uses IP literals so no DNS is
+ * needed. Self-contained stubs let it toggle single-site vs multisite.
+ */
+
+error_reporting(E_ALL & ~E_DEPRECATED);
+if (!defined('ABSPATH')) { define('ABSPATH', sys_get_temp_dir() . '/'); }
+
+class WP_Error { public $code; public $message; public function __construct($c = '', $m = '') { $this->code = $c; $this->message = $m; } }
+function is_wp_error($thing) { return $thing instanceof WP_Error; }
+function wp_parse_url($url) { return parse_url($url); }
+function apply_filters($tag, $value) { return $value; } // passthrough
+$GLOBALS['nmm_is_ms'] = false;
+function is_multisite() { return $GLOBALS['nmm_is_ms']; }
+
+require dirname(__DIR__) . '/src/NMM_Monero.php';
+
+$failed = false;
+function mok($label, $pass) { global $failed; printf("%-58s %s\n", $label, $pass ? 'ok' : 'FAIL'); if (!$pass) { $failed = true; } }
+function allowed($url) { return !is_wp_error(NMM_Monero::validate_rpc_url($url)); }
+
+// --- scheme / shape ---
+mok('rejects ftp scheme',            !allowed('ftp://8.8.8.8:18082/json_rpc'));
+mok('rejects file scheme',           !allowed('file:///etc/passwd'));
+mok('rejects gopher scheme',         !allowed('gopher://8.8.8.8:70'));
+mok('rejects malformed url',         !allowed('not a url'));
+mok('rejects empty',                 !allowed(''));
+
+// --- public host is always fine ---
+mok('allows public http host',       allowed('http://8.8.8.8:18082/json_rpc'));
+mok('allows public https host',      allowed('https://8.8.8.8/json_rpc'));
+
+// --- private / loopback / reserved: single-site allows, multisite blocks ---
+$GLOBALS['nmm_is_ms'] = false;
+mok('single-site allows loopback',      allowed('http://127.0.0.1:18082/json_rpc'));
+mok('single-site allows localhost',     allowed('http://localhost:18082/json_rpc'));
+mok('single-site allows private 10.x',  allowed('http://10.1.2.3:18082'));
+mok('single-site allows private 192.x', allowed('http://192.168.0.9:18082'));
+
+$GLOBALS['nmm_is_ms'] = true;
+mok('multisite blocks loopback',        !allowed('http://127.0.0.1:18082/json_rpc'));
+mok('multisite blocks localhost',       !allowed('http://localhost:18082/json_rpc'));
+mok('multisite blocks private 10.x',    !allowed('http://10.1.2.3:18082'));
+mok('multisite blocks private 172.16',  !allowed('http://172.16.5.5:18082'));
+mok('multisite blocks link-local meta', !allowed('http://169.254.169.254/latest/meta-data/'));
+mok('multisite blocks IPv6 loopback',   !allowed('http://[::1]:18082'));
+mok('multisite still allows public',    allowed('http://8.8.8.8:18082'));
+
+// --- explicit opt-in constant permits private on multisite ---
+define('NMM_XMR_ALLOW_PRIVATE_RPC', true);
+mok('constant opt-in allows private on multisite', allowed('http://127.0.0.1:18082/json_rpc'));
+
+exit($failed ? 1 : 0);

--- a/tests/test-monero-url.php
+++ b/tests/test-monero-url.php
@@ -58,6 +58,21 @@ $loopLiteral = NMM_Monero::validate_rpc_url('http://127.0.0.1:18082');
 mok('loopback literal: is_literal true',  $loopLiteral['is_literal'] === true);
 mok('loopback literal: is_private true',  $loopLiteral['is_private'] === true);
 
+// IPv6 literals: brackets stripped, classified as literal, address preserved.
+$v6Public = NMM_Monero::validate_rpc_url('http://[2001:4860:4860::8888]:18082');
+mok('ipv6 public literal: is_literal',    is_array($v6Public) && $v6Public['is_literal'] === true);
+mok('ipv6 public literal: ip debracketed',is_array($v6Public) && $v6Public['ip'] === '2001:4860:4860::8888');
+mok('ipv6 public literal: not private',   is_array($v6Public) && $v6Public['is_private'] === false);
+$GLOBALS['nmm_is_ms'] = false;
+$v6Loop = NMM_Monero::validate_rpc_url('http://[::1]:18082');
+mok('ipv6 loopback: is_literal',          is_array($v6Loop) && $v6Loop['is_literal'] === true);
+mok('ipv6 loopback: is_private',          is_array($v6Loop) && $v6Loop['is_private'] === true);
+mok('ipv6 loopback: ip preserved',        is_array($v6Loop) && $v6Loop['ip'] === '::1');
+
+// curl_resolve_entry: IPv6 addresses must be bracketed in HOST:PORT:ADDRESS.
+mok('resolve entry ipv4 plain',   NMM_Monero::curl_resolve_entry('wallet.example.com', 443, '93.184.216.34') === 'wallet.example.com:443:93.184.216.34');
+mok('resolve entry ipv6 bracketed', NMM_Monero::curl_resolve_entry('wallet.example.com', 18082, '2001:db8::1') === 'wallet.example.com:18082:[2001:db8::1]');
+
 // --- plan_request: transport must never resolve away from the vetted address ---
 // plan($target, $hasCurl, $canPin, $hasCreds)
 function plan($target, $curl, $canPin, $creds) { return NMM_Monero::plan_request($target, $curl, $canPin, $creds); }

--- a/tests/test-monero-url.php
+++ b/tests/test-monero-url.php
@@ -74,12 +74,13 @@ mok('curl pins private hostname',    plan($privateHost,   true, false)['transpor
 mok('curl digest off without creds', plan($publicLiteral, true, false)['digest'] === false);
 mok('curl digest on with creds',     plan($publicLiteral, true, true)['digest']  === true);
 
-// No cURL: IP literals are safe (no DNS), public hostnames go via safe transport.
+// No cURL: only IP literals are safe (no DNS to rebind).
 mok('no-curl ip literal -> wp_remote',   plan($publicLiteral,  false, false)['transport'] === 'wp_remote');
 mok('no-curl private literal -> wp_remote', plan($privateLiteral, false, false)['transport'] === 'wp_remote');
-mok('no-curl public host -> wp_safe',    plan($publicHost,     false, false)['transport'] === 'wp_safe');
 
-// No cURL: a private/unresolvable hostname we cannot pin must be refused.
+// No cURL: EVERY hostname is refused - a public host is just as rebindable as a
+// private one because the resolved IP at connect time cannot be pinned.
+mok('no-curl public host -> reject',     plan($publicHost,     false, false)['transport'] === 'reject');
 mok('no-curl private host -> reject',    plan($privateHost,    false, false)['transport'] === 'reject');
 mok('no-curl unresolvable -> reject',    plan($unresolvable,   false, false)['transport'] === 'reject');
 // Even with cURL, nothing to pin (no ip) must not fall through to an unpinned send.

--- a/tests/test-monero-url.php
+++ b/tests/test-monero-url.php
@@ -48,7 +48,45 @@ mok('multisite blocks link-local meta', !allowed('http://169.254.169.254/latest/
 mok('multisite blocks IPv6 loopback',   !allowed('http://[::1]:18082'));
 mok('multisite still allows public',    allowed('http://8.8.8.8:18082'));
 
+// --- validate_rpc_url now reports literal / private shape ---
+$GLOBALS['nmm_is_ms'] = false;
+$pubLiteral = NMM_Monero::validate_rpc_url('http://8.8.8.8:18082');
+mok('public literal: is_literal true',  $pubLiteral['is_literal'] === true);
+mok('public literal: is_private false', $pubLiteral['is_private'] === false);
+mok('public literal: ip pinned',        $pubLiteral['ip'] === '8.8.8.8');
+$loopLiteral = NMM_Monero::validate_rpc_url('http://127.0.0.1:18082');
+mok('loopback literal: is_literal true',  $loopLiteral['is_literal'] === true);
+mok('loopback literal: is_private true',  $loopLiteral['is_private'] === true);
+
+// --- plan_request: transport must never resolve away from the vetted address ---
+function plan($target, $curl, $creds) { return NMM_Monero::plan_request($target, $curl, $creds); }
+
+$publicLiteral  = array('host' => '8.8.8.8',            'port' => 18082, 'ip' => '8.8.8.8',       'is_literal' => true,  'is_private' => false);
+$publicHost     = array('host' => 'wallet.example.com','port' => 443,   'ip' => '93.184.216.34', 'is_literal' => false, 'is_private' => false);
+$privateLiteral = array('host' => '127.0.0.1',         'port' => 18082, 'ip' => '127.0.0.1',     'is_literal' => true,  'is_private' => true);
+$privateHost    = array('host' => 'localhost',         'port' => 18082, 'ip' => '127.0.0.1',     'is_literal' => false, 'is_private' => true);
+$unresolvable   = array('host' => 'nope.invalid',      'port' => 80,    'ip' => '',              'is_literal' => false, 'is_private' => true);
+
+// cURL available: always pin, regardless of host or privacy.
+mok('curl pins public literal',      plan($publicLiteral, true, false)['transport'] === 'curl');
+mok('curl pins public hostname',     plan($publicHost,    true, false)['transport'] === 'curl');
+mok('curl pins private hostname',    plan($privateHost,   true, false)['transport'] === 'curl');
+mok('curl digest off without creds', plan($publicLiteral, true, false)['digest'] === false);
+mok('curl digest on with creds',     plan($publicLiteral, true, true)['digest']  === true);
+
+// No cURL: IP literals are safe (no DNS), public hostnames go via safe transport.
+mok('no-curl ip literal -> wp_remote',   plan($publicLiteral,  false, false)['transport'] === 'wp_remote');
+mok('no-curl private literal -> wp_remote', plan($privateLiteral, false, false)['transport'] === 'wp_remote');
+mok('no-curl public host -> wp_safe',    plan($publicHost,     false, false)['transport'] === 'wp_safe');
+
+// No cURL: a private/unresolvable hostname we cannot pin must be refused.
+mok('no-curl private host -> reject',    plan($privateHost,    false, false)['transport'] === 'reject');
+mok('no-curl unresolvable -> reject',    plan($unresolvable,   false, false)['transport'] === 'reject');
+// Even with cURL, nothing to pin (no ip) must not fall through to an unpinned send.
+mok('curl but no ip -> reject',          plan($unresolvable,   true,  false)['transport'] === 'reject');
+
 // --- explicit opt-in constant permits private on multisite ---
+$GLOBALS['nmm_is_ms'] = true;
 define('NMM_XMR_ALLOW_PRIVATE_RPC', true);
 mok('constant opt-in allows private on multisite', allowed('http://127.0.0.1:18082/json_rpc'));
 

--- a/tests/test-monero-url.php
+++ b/tests/test-monero-url.php
@@ -59,7 +59,8 @@ mok('loopback literal: is_literal true',  $loopLiteral['is_literal'] === true);
 mok('loopback literal: is_private true',  $loopLiteral['is_private'] === true);
 
 // --- plan_request: transport must never resolve away from the vetted address ---
-function plan($target, $curl, $creds) { return NMM_Monero::plan_request($target, $curl, $creds); }
+// plan($target, $hasCurl, $canPin, $hasCreds)
+function plan($target, $curl, $canPin, $creds) { return NMM_Monero::plan_request($target, $curl, $canPin, $creds); }
 
 $publicLiteral  = array('host' => '8.8.8.8',            'port' => 18082, 'ip' => '8.8.8.8',       'is_literal' => true,  'is_private' => false);
 $publicHost     = array('host' => 'wallet.example.com','port' => 443,   'ip' => '93.184.216.34', 'is_literal' => false, 'is_private' => false);
@@ -67,24 +68,32 @@ $privateLiteral = array('host' => '127.0.0.1',         'port' => 18082, 'ip' => 
 $privateHost    = array('host' => 'localhost',         'port' => 18082, 'ip' => '127.0.0.1',     'is_literal' => false, 'is_private' => true);
 $unresolvable   = array('host' => 'nope.invalid',      'port' => 80,    'ip' => '',              'is_literal' => false, 'is_private' => true);
 
-// cURL available: always pin, regardless of host or privacy.
-mok('curl pins public literal',      plan($publicLiteral, true, false)['transport'] === 'curl');
-mok('curl pins public hostname',     plan($publicHost,    true, false)['transport'] === 'curl');
-mok('curl pins private hostname',    plan($privateHost,   true, false)['transport'] === 'curl');
-mok('curl digest off without creds', plan($publicLiteral, true, false)['digest'] === false);
-mok('curl digest on with creds',     plan($publicLiteral, true, true)['digest']  === true);
+// cURL that can pin: pin every host, public or private.
+mok('curl pins public literal',      plan($publicLiteral, true, true, false)['transport'] === 'curl');
+mok('curl pins public hostname',     plan($publicHost,    true, true, false)['transport'] === 'curl');
+mok('curl pins private hostname',    plan($privateHost,   true, true, false)['transport'] === 'curl');
+mok('curl digest off without creds', plan($publicLiteral, true, true, false)['digest'] === false);
+mok('curl digest on with creds',     plan($publicLiteral, true, true, true)['digest']  === true);
+
+// cURL present but the build CANNOT pin (no CURLOPT_RESOLVE): a hostname must be
+// refused (it would send unpinned), while an IP literal is still safe over cURL
+// - no DNS to rebind - and keeps digest auth working.
+mok('curl no-pin public host -> reject',   plan($publicHost,    true, false, false)['transport'] === 'reject');
+mok('curl no-pin private host -> reject',  plan($privateHost,   true, false, false)['transport'] === 'reject');
+mok('curl no-pin ip literal -> curl',      plan($publicLiteral, true, false, false)['transport'] === 'curl');
+mok('curl no-pin ip literal keeps digest', plan($privateLiteral, true, false, true)['digest'] === true);
 
 // No cURL: only IP literals are safe (no DNS to rebind).
-mok('no-curl ip literal -> wp_remote',   plan($publicLiteral,  false, false)['transport'] === 'wp_remote');
-mok('no-curl private literal -> wp_remote', plan($privateLiteral, false, false)['transport'] === 'wp_remote');
+mok('no-curl ip literal -> wp_remote',      plan($publicLiteral,  false, false, false)['transport'] === 'wp_remote');
+mok('no-curl private literal -> wp_remote', plan($privateLiteral, false, false, false)['transport'] === 'wp_remote');
 
 // No cURL: EVERY hostname is refused - a public host is just as rebindable as a
 // private one because the resolved IP at connect time cannot be pinned.
-mok('no-curl public host -> reject',     plan($publicHost,     false, false)['transport'] === 'reject');
-mok('no-curl private host -> reject',    plan($privateHost,    false, false)['transport'] === 'reject');
-mok('no-curl unresolvable -> reject',    plan($unresolvable,   false, false)['transport'] === 'reject');
-// Even with cURL, nothing to pin (no ip) must not fall through to an unpinned send.
-mok('curl but no ip -> reject',          plan($unresolvable,   true,  false)['transport'] === 'reject');
+mok('no-curl public host -> reject',     plan($publicHost,     false, false, false)['transport'] === 'reject');
+mok('no-curl private host -> reject',    plan($privateHost,    false, false, false)['transport'] === 'reject');
+mok('no-curl unresolvable -> reject',    plan($unresolvable,   false, false, false)['transport'] === 'reject');
+// Can pin in principle, but no ip to pin and not a literal: must not fall through.
+mok('curl but no ip -> reject',          plan($unresolvable,   true,  true,  false)['transport'] === 'reject');
 
 // --- explicit opt-in constant permits private on multisite ---
 $GLOBALS['nmm_is_ms'] = true;

--- a/tests/test-sol-retry.php
+++ b/tests/test-sol-retry.php
@@ -28,8 +28,11 @@ $t = $wpdb->prefix . NMM_SOL_RETRY_TABLE;
 NMM_create_sol_retry_table();
 $wpdb->query("DELETE FROM `$t`");
 
-$pass = true;
-function rok($label, $cond, $extra = '') { global $pass; printf("%-56s %s%s\n", $label, $cond ? 'ok' : 'FAIL', $extra !== '' ? "  $extra" : ''); if (!$cond) { $pass = false; } }
+// wp eval-file runs this file in function scope, so a top-level `$pass` is not
+// the `global $pass` rok() writes; track through $GLOBALS so the banner (which
+// CI greps) can never print PASSED while a check failed.
+$GLOBALS['sr_ok'] = true;
+function rok($label, $cond, $extra = '') { printf("%-56s %s%s\n", $label, $cond ? 'ok' : 'FAIL', $extra !== '' ? "  $extra" : ''); if (!$cond) { $GLOBALS['sr_ok'] = false; } }
 
 $LIFE = 100000;
 $now = time();
@@ -245,4 +248,4 @@ $drained = NMM_Sol_Retry_Repo::run_global_cleanup(7 * 24 * 60 * 60, 0, 500, 40);
 rok('drains a 1200-row backlog across bounded batches', (int) $wpdb->get_var("SELECT COUNT(*) FROM `$t` WHERE address='DRAIN'") === 0, "drained=$drained");
 
 $wpdb->query("DELETE FROM `$t`");
-echo $pass ? "\nSOL-RETRY (durable queue) CHECKS PASSED\n" : "\nSOL-RETRY CHECKS FAILED\n";
+echo $GLOBALS['sr_ok'] ? "\nSOL-RETRY (durable queue) CHECKS PASSED\n" : "\nSOL-RETRY CHECKS FAILED\n";


### PR DESCRIPTION
Addresses a full repository-wide audit (at `465a845`) that found one payment-correctness blocker and several hardening/performance issues outside the 2.9.3 PR.

## [P1] Autopay expiry could cancel an already-paid order
`NMM_Payment::cancel_expired_payments()` read an unpaid snapshot and then cancelled the order without re-checking it — a merchant/webhook/verifier could pay it in between. This is the legacy Autopay analogue of the HD cancellation race fixed in 2.9.3. Now it re-checks the live order right before touching state: deleted → retire the orphaned record; paid → reconcile to `paid`, leave the order; terminal non-paid → reconcile without re-cancelling; only pending/on-hold is cancelled. Covered by `tests/test-autopay-cancel.php` across all seven states.

## [P2] Operational logging was disabled
`NMM_Util::log()` was fully commented out, so every safety-mechanism message was discarded. Restored: routes to **WooCommerce > Status > Logs** (source `nomiddleman`), `error_log()` fallback, severity levels (warnings+ always emitted, verbose only when debug enabled via `WP_DEBUG` / `NMM_DEBUG_LOG` / `nmm_debug_logging`), de-duplication, and length-capping (no dumping full third-party responses). High-severity call sites now pass explicit levels.

## [P2] Missing hot-path indexes
Added composite indexes so hot queries stop scanning as tables grow, via the verify-before-record migration pattern (new installs + existing):
- HD (1.3→1.4): `order_lookup (order_id, id)` for the 15s status poll; `hd_pool (cryptocurrency, hd_mode, status, mpk_index)` and `hd_wallet_status (…, mpk)` for the cron's pool/claim/pending/assigned queries.
- Payment: `unpaid_address (status, cryptocurrency, address)` for the matcher; `unpaid_expiry (status, ordered_at)` for expiry.
- `EXPLAIN` on seeded data confirms the new indexes are used.

## [P2] Monero RPC SSRF
The merchant-configured RPC URL was requested with only a `FILTER_VALIDATE_URL` check. Added `validate_rpc_url()`: require http/https; reject private/loopback/link-local/reserved targets (resolving the host, catching hostname→private); allow such targets only on single-site or via `NMM_XMR_ALLOW_PRIVATE_RPC` / `nmm_xmr_allow_private_rpc` on multisite. Hardened requests: protocol-restricted cURL, no redirect following (cURL + `wp_remote_post`), and connection pinned to the validated IP (DNS-rebinding). Covered by `tests/test-monero-url.php` (offline).

## Testing / CI
- New offline job runs the Solana sweep + Monero SSRF tests.
- The database job now installs **WooCommerce** and runs both the durable-retry and the Autopay-cancellation tests, failing if either skips.
- Verified end-to-end on a real WordPress + WooCommerce + MariaDB stack; `EXPLAIN`-validated the indexes.

Bumps to 2.9.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)