### PR TITLE
2.9.5: concurrency-safe thank-you init + bounded Autopay scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,3 +137,15 @@ jobs:
           echo "$OUT"
           echo "$OUT" | grep -qi "skipped" && { echo "::error::autopay test skipped"; exit 1; } || true
           echo "$OUT" | grep -q "AUTOPAY-CANCEL CHECKS PASSED" || { echo "::error::autopay test did not pass"; exit 1; }
+      - name: Bounded Autopay scan (budget + fair cursor + Monero batch) test (must run, not skip)
+        run: |
+          OUT=$(wp eval-file "$GITHUB_WORKSPACE/plugin/tests/test-autopay-scan.php" --path=wp 2>&1)
+          echo "$OUT"
+          echo "$OUT" | grep -qi "skipped" && { echo "::error::scan test skipped"; exit 1; } || true
+          echo "$OUT" | grep -q "AUTOPAY-SCAN CHECKS PASSED" || { echo "::error::scan test did not pass"; exit 1; }
+      - name: Per-order initialization lock test (must run, not skip)
+        run: |
+          OUT=$(wp eval-file "$GITHUB_WORKSPACE/plugin/tests/test-order-init-lock.php" --path=wp 2>&1)
+          echo "$OUT"
+          echo "$OUT" | grep -qi "skipped" && { echo "::error::order-init-lock test skipped"; exit 1; } || true
+          echo "$OUT" | grep -q "ORDER-INIT-LOCK CHECKS PASSED" || { echo "::error::order-init-lock test did not pass"; exit 1; }

--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Requires at least: 5.0
 Tested up to: 7.0
 Requires PHP: 7.4
 License: GPL v3
-Stable Tag: 2.9.4
+Stable Tag: 2.9.5
 
 Absolutely the easiest setup in the industry. No registration. No API keys. No middleman. Accept bitcoin, ethereum, litecoin, and more.
 
@@ -182,6 +182,10 @@ Yes. Filters are available for redirecting verification requests, customizing th
 Yes - as a safeguard. Privacy Mode derives a fresh address per order from your master public key. To avoid handing out an ever-growing range of addresses, the plugin returns an address to the pool for reuse **only** if the order was abandoned without paying and fresh block-explorer checks confirm the address never received anything on-chain; any address that saw funds is retired permanently. This keeps a run of abandoned checkouts from advancing the derivation index unnecessarily. As defense-in-depth, set your receiving wallet's **gap limit** (the number of consecutive unused addresses it scans from the seed - 20 by default in Electrum) comfortably above the longest run of abandoned checkouts you would expect between payments, so a paid address is always discovered on seed recovery. In Electrum this is `wallet.change_gap_limit` / the `gap_limit_for_change` and address gap-limit settings; other HD wallets have an equivalent. This wallet setting should be a backstop, not the plugin's primary protection.
 
 == Changelog ==
+
+= 2.9.5 =
+* Autopay/Privacy Mode: the thank-you page now allocates a payment address under an order-scoped database lock and re-checks the order after acquiring it, so two near-simultaneous first loads of the same order can no longer each allocate a different address (most visible with Monero subaddresses and carousel addresses) - exactly one address is assigned and the displayed address always matches the one being monitored
+* Performance: the Autopay verifier now checks a bounded number of unpaid addresses per cron tick and advances a persisted fair cursor so every address is still eventually checked - a large backlog of abandoned orders can no longer hold the cron lock and delay payment, expiry, HD and Solana work. Monero verification fetches an account's incoming transfers once per tick and groups them by subaddress locally, instead of two wallet-RPC calls per address
 
 = 2.9.4 =
 * Autopay: the background job no longer cancels an order that was paid (by the merchant, a webhook, or the verifier) after its unpaid record was read but before cancellation - it re-checks the live order and reconciles the payment record instead. This is the Autopay counterpart of the HD-address cancellation fix in 2.9.3

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -141,6 +141,22 @@ abandoned checkouts from pushing a later *paid* address beyond your wallet's
 the seed — 20 by default in Electrum). See the "gap limit" note in the FAQ for
 the recommended wallet-side safeguard.
 
+### `nmm_autopay_scan_budget`
+
+The maximum number of distinct unpaid payment addresses the Autopay verifier
+checks per cron tick (default `50`). Each non-Monero address costs a block-explorer
+request, so this bounds the external work a large backlog of abandoned, unpaid
+orders can trigger under the background job's lock — stopping it from starving
+payment, expiry, HD and Solana work. A persisted fair cursor resumes after the
+last address checked and wraps around, so every address is still checked within a
+few ticks. Monero is already cheap regardless of this value: an account's incoming
+transfers are fetched once per tick and grouped by subaddress locally. Raise it if
+you have a large backlog and explorer headroom; lower it to be gentler.
+
+```php
+apply_filters( 'nmm_autopay_scan_budget', $limit );
+```
+
 ### `nmm_sol_retry_global_retention_seconds`
 
 How long a durable Solana retry entry is kept before a global cleanup pass may

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -143,15 +143,21 @@ the recommended wallet-side safeguard.
 
 ### `nmm_autopay_scan_budget`
 
-The maximum number of distinct unpaid payment addresses the Autopay verifier
+The **baseline** number of distinct unpaid payment addresses the Autopay verifier
 checks per cron tick (default `50`). Each non-Monero address costs a block-explorer
-request, so this bounds the external work a large backlog of abandoned, unpaid
-orders can trigger under the background job's lock — stopping it from starving
-payment, expiry, HD and Solana work. A persisted fair cursor resumes after the
-last address checked and wraps around, so every address is still checked within a
-few ticks. Monero is already cheap regardless of this value: an account's incoming
-transfers are fetched once per tick and grouped by subaddress locally. Raise it if
-you have a large backlog and explorer headroom; lower it to be gentler.
+request, so spreading the work with a persisted fair cursor (which resumes after
+the last address checked and wraps around) keeps a large backlog of abandoned,
+unpaid orders from holding the background job's lock for one long tick and starving
+payment, expiry, HD and Solana work.
+
+This is a floor, not a hard cap: the plugin raises the budget above it when a
+backlog is large enough that sweeping it at the baseline would take longer than the
+payment-matching window, because an address must be re-checked within that window
+or a just-arrived payment could age out before it is seen. Monero is cheap
+regardless of the value — an account's recent incoming transfers are fetched once
+per tick and grouped by subaddress locally. Raise the baseline if you want more
+frequent checks and have explorer headroom; lower it to be gentler on explorers for
+small backlogs.
 
 ```php
 apply_filters( 'nmm_autopay_scan_budget', $limit );

--- a/nomiddleman-crypto-woocommerce.php
+++ b/nomiddleman-crypto-woocommerce.php
@@ -323,6 +323,7 @@ function NMM_uninstall() {
     NMM_drop_carousel_table();
     NMM_drop_sol_retry_table();
     delete_option('nmm_autopay_scan_cursor');
+    delete_option('nmm_autopay_scan_retry');
 }
 
 // The retry table is created per site (each blog has its own prefix), so drop it

--- a/nomiddleman-crypto-woocommerce.php
+++ b/nomiddleman-crypto-woocommerce.php
@@ -7,7 +7,7 @@ Plugin URI:  https://wordpress.org/plugins/nomiddleman-crypto-payments-for-wooco
 Description: WooCommerce Bitcoin and Cryptocurrency Payment Gateway
 Author: nomiddleman
 Author URI: https://github.com/rmwb/nomiddleman-woocommerce
-Version: 2.9.4
+Version: 2.9.5
 Requires PHP: 7.4
 Text Domain: nomiddleman-crypto-payments-for-woocommerce
 Domain Path: /languages
@@ -71,7 +71,7 @@ function NMM_init_gateways(){
     define('NMM_PLUGIN_FILE', __FILE__);
     define('NMM_ABS_PATH', dirname(NMM_PLUGIN_FILE));
 
-    define('NMM_VERSION', '2.9.4');
+    define('NMM_VERSION', '2.9.5');
     
     define('NMM_REDUX_SLUG', 'nmmpro_options');
 
@@ -322,6 +322,7 @@ function NMM_uninstall() {
     NMM_drop_payment_table();
     NMM_drop_carousel_table();
     NMM_drop_sol_retry_table();
+    delete_option('nmm_autopay_scan_cursor');
 }
 
 // The retry table is created per site (each blog has its own prefix), so drop it

--- a/src/NMM_Gateway.php
+++ b/src/NMM_Gateway.php
@@ -212,12 +212,23 @@ class NMM_Gateway extends WC_Payment_Gateway {
                     return;
                 }
 
+                if ($lockResult === '0') {
+                    // The lock works and another request holds it: that request is
+                    // still initializing this order (a slow first load - exchange
+                    // rate or wallet RPC). We must NOT allocate a second address -
+                    // that is exactly the race this lock prevents. Ask the customer
+                    // to refresh; the fast path above will then show the address the
+                    // other request assigns.
+                    NMM_Util::log(__FILE__, __LINE__, 'Order-init lock busy for order ' . $order_id . '; another request is still initializing. Asking the customer to refresh.', 'warning');
+                    echo '<p class="nmm-status-pending">' . esc_html__('We are preparing your payment details. This will be ready in a few seconds - please refresh this page.', 'nomiddleman-crypto-payments-for-woocommerce') . '</p>';
+                    return;
+                }
+
                 if ($lockResult !== '1') {
-                    // Timed out waiting, or advisory locks are unavailable on this
-                    // host. Initialize anyway rather than erroring the customer's
-                    // order; the race window is now tiny and this matches the
-                    // pre-lock behaviour.
-                    NMM_Util::log(__FILE__, __LINE__, 'Order-init lock not acquired for order ' . $order_id . ' (' . var_export($lockResult, true) . '); initializing without overlap protection.', 'warning');
+                    // null: advisory locks are unavailable on this host. Degrade to
+                    // initializing without overlap protection (matching the pre-lock
+                    // behaviour) rather than never allocating an address at all.
+                    NMM_Util::log(__FILE__, __LINE__, 'Advisory locks unavailable on this host; initializing order ' . $order_id . ' without overlap protection.', 'warning');
                 }
 
             $nmmSettings = new NMM_Settings(get_option(NMM_REDUX_ID));

--- a/src/NMM_Gateway.php
+++ b/src/NMM_Gateway.php
@@ -185,32 +185,40 @@ class NMM_Gateway extends WC_Payment_Gateway {
         
         try {
             $order = wc_get_order($order_id);
-            $existingWalletAddress = $order->get_meta('wallet_address');
 
-            // if we already set this then we are on a page refresh, so handle refresh
-            if (!empty($existingWalletAddress)) {
-
-                if ($order->is_paid()) {
-                    echo '<p class="nmm-status-paid">' . esc_html__('Payment received - thank you! Your order is being processed.', 'nomiddleman-crypto-payments-for-woocommerce') . '</p>';
-                    return;
-                }
-
-                // Do not re-display payment instructions for an order that is no
-                // longer awaiting payment. Its address may have been recycled to
-                // a different order, so a late payment would credit someone else.
-                if ($order->has_status(array('cancelled', 'failed'))) {
-                    echo '<p class="nmm-status-cancelled">' . esc_html__('This order is no longer awaiting payment. Please do not send any funds to the address shown previously. If you believe this is an error, contact the store.', 'nomiddleman-crypto-payments-for-woocommerce') . '</p>';
-                    return;
-                }
-
-                $this->handle_thank_you_refresh(
-                    $order->get_meta('crypto_type_id'),
-                    $existingWalletAddress,
-                    $order->get_meta('crypto_amount'),
-                    $order_id);
-
+            // Fast path: the address is already allocated (a page refresh). No
+            // lock is needed just to re-display it.
+            if (!empty($order->get_meta('wallet_address'))) {
+                $this->display_existing_payment($order, $order_id);
                 return;
             }
+
+            // First load. Serialize per-order initialization so two near-
+            // simultaneous first loads of the same order cannot both allocate an
+            // address: with Monero subaddresses or carousel addresses each worker
+            // would mint a DIFFERENT address, and the last meta write could differ
+            // from the address recorded in the payment table, leaving the
+            // displayed address unmonitored. Uses the same crash-safe MySQL
+            // advisory lock the cron uses.
+            $lockResult = NMM_Util::acquire_order_init_lock($order_id);
+
+            try {
+                // Re-fetch under the lock: another worker may have finished
+                // initializing while we waited for it. If so, just display that
+                // address and never allocate a second one.
+                $order = wc_get_order($order_id);
+                if (!empty($order->get_meta('wallet_address'))) {
+                    $this->display_existing_payment($order, $order_id);
+                    return;
+                }
+
+                if ($lockResult !== '1') {
+                    // Timed out waiting, or advisory locks are unavailable on this
+                    // host. Initialize anyway rather than erroring the customer's
+                    // order; the race window is now tiny and this matches the
+                    // pre-lock behaviour.
+                    NMM_Util::log(__FILE__, __LINE__, 'Order-init lock not acquired for order ' . $order_id . ' (' . var_export($lockResult, true) . '); initializing without overlap protection.', 'warning');
+                }
 
             $nmmSettings = new NMM_Settings(get_option(NMM_REDUX_ID));
 
@@ -334,6 +342,15 @@ class NMM_Gateway extends WC_Payment_Gateway {
 
             // Output additional thank you page html
             $this->output_thank_you_html($crypto, $orderWalletAddress, $formattedCryptoTotal, $order_id);
+            }
+            finally {
+                // Release only the lock we actually acquired ('1'); on '0'/null we
+                // never held it. Runs on the normal path, on an early return above,
+                // and if allocation throws (propagating to the outer catch).
+                if ($lockResult === '1') {
+                    NMM_Util::release_order_init_lock($order_id);
+                }
+            }
         }
         catch ( \Exception $e ) {
             $order = wc_get_order($order_id);
@@ -351,6 +368,31 @@ class NMM_Gateway extends WC_Payment_Gateway {
             echo '</ul>';
             echo '</div>';
         }
+    }
+
+    // Re-display an order whose payment address was already allocated (page
+    // refresh, or a concurrent first load that lost the init lock). Shows a
+    // terminal message for paid/cancelled/failed orders, otherwise the live
+    // payment status. Never allocates - allocation happens once, under the lock.
+    private function display_existing_payment($order, $order_id) {
+        if ($order->is_paid()) {
+            echo '<p class="nmm-status-paid">' . esc_html__('Payment received - thank you! Your order is being processed.', 'nomiddleman-crypto-payments-for-woocommerce') . '</p>';
+            return;
+        }
+
+        // Do not re-display payment instructions for an order that is no longer
+        // awaiting payment. Its address may have been recycled to a different
+        // order, so a late payment would credit someone else.
+        if ($order->has_status(array('cancelled', 'failed'))) {
+            echo '<p class="nmm-status-cancelled">' . esc_html__('This order is no longer awaiting payment. Please do not send any funds to the address shown previously. If you believe this is an error, contact the store.', 'nomiddleman-crypto-payments-for-woocommerce') . '</p>';
+            return;
+        }
+
+        $this->handle_thank_you_refresh(
+            $order->get_meta('crypto_type_id'),
+            $order->get_meta('wallet_address'),
+            $order->get_meta('crypto_amount'),
+            $order_id);
     }
 
     public function additional_email_details($order, $sent_to_admin, $plain_text, $email) {

--- a/src/NMM_Gateway.php
+++ b/src/NMM_Gateway.php
@@ -205,9 +205,16 @@ class NMM_Gateway extends WC_Payment_Gateway {
             try {
                 // Re-fetch under the lock: another worker may have finished
                 // initializing while we waited for it. If so, just display that
-                // address and never allocate a second one.
+                // address and never allocate a second one. Force a fresh meta read
+                // (bypassing the request-local cache the pre-lock get_meta() above
+                // populated with an empty wallet_address) so we actually see what
+                // the worker that held the lock just committed - a stale cache here
+                // would let us allocate a second, unmonitored address.
                 $order = wc_get_order($order_id);
-                if (!empty($order->get_meta('wallet_address'))) {
+                if ($order) {
+                    $order->read_meta_data(true);
+                }
+                if ($order && !empty($order->get_meta('wallet_address'))) {
                     $this->display_existing_payment($order, $order_id);
                     return;
                 }

--- a/src/NMM_Gateway.php
+++ b/src/NMM_Gateway.php
@@ -201,6 +201,7 @@ class NMM_Gateway extends WC_Payment_Gateway {
             // displayed address unmonitored. Uses the same crash-safe MySQL
             // advisory lock the cron uses.
             $lockResult = NMM_Util::acquire_order_init_lock($order_id);
+            $initializing = false; // becomes true once we commit to allocating
 
             try {
                 // Re-fetch under the lock: another worker may have finished
@@ -237,6 +238,10 @@ class NMM_Gateway extends WC_Payment_Gateway {
                     // behaviour) rather than never allocating an address at all.
                     NMM_Util::log(__FILE__, __LINE__, 'Advisory locks unavailable on this host; initializing order ' . $order_id . ' without overlap protection.', 'warning');
                 }
+
+            // From here we are allocating; a throw past this point must fail the
+            // order while we still hold the lock (see the catch below).
+            $initializing = true;
 
             $nmmSettings = new NMM_Settings(get_option(NMM_REDUX_ID));
 
@@ -361,31 +366,53 @@ class NMM_Gateway extends WC_Payment_Gateway {
             // Output additional thank you page html
             $this->output_thank_you_html($crypto, $orderWalletAddress, $formattedCryptoTotal, $order_id);
             }
+            catch ( \Exception $e ) {
+                // Initialization failed. Mark the order failed HERE, while we still
+                // hold the lock, so a concurrent first-load request that is waiting
+                // cannot acquire the lock, allocate a fresh address, reach on-hold,
+                // and then have this delayed failure overwrite it - which would
+                // leave a monitored payment address on a failed order. Only fail if
+                // we had actually begun allocating ($initializing); an error while
+                // re-displaying an already-initialized order must not fail it.
+                if ($initializing) {
+                    $failedOrder = wc_get_order($order_id);
+                    if ($failedOrder) {
+                        /* translators: %s: error message */
+                        $failedOrder->update_status('wc-failed', sprintf(__('Error Message: %s', 'nomiddleman-crypto-payments-for-woocommerce'), $e->getMessage()));
+                    }
+                }
+                NMM_Util::log(__FILE__, __LINE__, 'Something went wrong during checkout: ' . $e->getMessage());
+                $this->render_checkout_error($e->getMessage());
+            }
             finally {
                 // Release only the lock we actually acquired ('1'); on '0'/null we
                 // never held it. Runs on the normal path, on an early return above,
-                // and if allocation throws (propagating to the outer catch).
+                // and AFTER the failure handling above - so the lock covers the
+                // whole of initialization and its error handling together.
                 if ($lockResult === '1') {
                     NMM_Util::release_order_init_lock($order_id);
                 }
             }
         }
         catch ( \Exception $e ) {
-            $order = wc_get_order($order_id);
-
-            // cancel order if something went wrong
-            /* translators: %s: error message */
-            $order->update_status('wc-failed', sprintf(__('Error Message: %s', 'nomiddleman-crypto-payments-for-woocommerce'), $e->getMessage()));
-            NMM_Util::log(__FILE__, __LINE__, 'Something went wrong during checkout: ' . $e->getMessage());
-            echo '<div class="woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout">';
-            echo '<ul class="woocommerce-error">';
-            echo '<li>';
-            echo esc_html__('Something went wrong.', 'nomiddleman-crypto-payments-for-woocommerce') . '<br>';
-            echo esc_html($e->getMessage());
-            echo '</li>';
-            echo '</ul>';
-            echo '</div>';
+            // Errors from the fast path (re-displaying an already-initialized
+            // order). Do not fail the order for a display hiccup - it may already
+            // be paid; just surface the message. Initialization failures are
+            // handled and failed under the lock above.
+            NMM_Util::log(__FILE__, __LINE__, 'Error rendering the payment page: ' . $e->getMessage());
+            $this->render_checkout_error($e->getMessage());
         }
+    }
+
+    private function render_checkout_error($message) {
+        echo '<div class="woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout">';
+        echo '<ul class="woocommerce-error">';
+        echo '<li>';
+        echo esc_html__('Something went wrong.', 'nomiddleman-crypto-payments-for-woocommerce') . '<br>';
+        echo esc_html($message);
+        echo '</li>';
+        echo '</ul>';
+        echo '</div>';
     }
 
     // Re-display an order whose payment address was already allocated (page

--- a/src/NMM_Monero.php
+++ b/src/NMM_Monero.php
@@ -377,6 +377,14 @@ class NMM_Monero {
 	public static function get_account_transactions($lifetimeSeconds) {
 		do_action('nmm_xmr_account_fetch');
 
+		// Seam for integrations (a self-hosted indexer) and tests: a filter may
+		// supply the batch result array directly instead of the wallet RPC. Return
+		// anything non-array (the default null) to use the real RPC below.
+		$injected = apply_filters('nmm_xmr_account_transactions', null, $lifetimeSeconds);
+		if (is_array($injected)) {
+			return $injected;
+		}
+
 		// Read the wallet height first so we can bound the transfer query. If this
 		// fails the wallet RPC is unreachable and the transfer call would fail too,
 		// so skip the tick rather than fall back to an unbounded fetch.

--- a/src/NMM_Monero.php
+++ b/src/NMM_Monero.php
@@ -348,25 +348,55 @@ class NMM_Monero {
 		);
 	}
 
+	// Lowest block height whose confirmed transfers we still need to fetch to
+	// cover a payment window of $lifetimeSeconds, given the current wallet height.
+	// Monero targets ~120s per block; we look back twice the window plus a fixed
+	// margin so block-time variance or a shallow reorg can never drop an in-window
+	// transfer (the matcher's own timestamp check is the authoritative filter).
+	// Clamped at 0. Pure, so it can be unit-tested.
+	public static function lookback_min_height($currentHeight, $lifetimeSeconds) {
+		$lifetimeSeconds = max(0, (int) $lifetimeSeconds);
+		$lookbackBlocks = (int) ceil($lifetimeSeconds / 120) * 2 + 30;
+
+		return max(0, (int) $currentHeight - $lookbackBlocks);
+	}
+
 	/**
-	 * All incoming transfers for account 0 in ONE wallet-RPC call, grouped by the
-	 * receiving subaddress. The cron uses this to check many unpaid Monero orders
-	 * per tick with a single get_transfers instead of two RPC calls
-	 * (get_address_index + get_transfers) per address. Returns
-	 * { result: 'success', by_address: { address => NMM_Transaction[] } } or
-	 * { result: 'error' } so callers can skip this tick without crediting anyone.
+	 * Incoming transfers for account 0 within roughly the payment window, in ONE
+	 * get_transfers call, grouped by the receiving subaddress. The cron uses this
+	 * to check many unpaid Monero orders per tick instead of two RPC calls
+	 * (get_address_index + get_transfers) per address.
+	 *
+	 * The query is bounded to recent blocks (filter_by_height + min_height) so an
+	 * established wallet's full incoming history is never fetched every tick -
+	 * pool (unconfirmed) transfers are unaffected by the height filter and always
+	 * included. Returns { result: 'success', by_address: { address =>
+	 * NMM_Transaction[] } } or { result: 'error' } so callers can skip this tick
+	 * without crediting anyone.
 	 */
-	public static function get_account_transactions() {
+	public static function get_account_transactions($lifetimeSeconds) {
 		do_action('nmm_xmr_account_fetch');
+
+		// Read the wallet height first so we can bound the transfer query. If this
+		// fails the wallet RPC is unreachable and the transfer call would fail too,
+		// so skip the tick rather than fall back to an unbounded fetch.
+		$heightResult = self::rpc('get_height');
+		if (is_wp_error($heightResult) || !isset($heightResult->height)) {
+			NMM_Util::log(__FILE__, __LINE__, 'XMR batch: could not read wallet height; skipping this tick.');
+
+			return array('result' => 'error');
+		}
 
 		$result = self::rpc('get_transfers', array(
 			'in' => true,
 			'pool' => true,
 			'account_index' => 0,
+			'filter_by_height' => true,
+			'min_height' => self::lookback_min_height((int) $heightResult->height, $lifetimeSeconds),
 		));
 
 		if (is_wp_error($result)) {
-			NMM_Util::log(__FILE__, __LINE__, 'XMR batch RPC failed: ' . $result->get_error_message());
+			NMM_Util::log(__FILE__, __LINE__, 'XMR batch get_transfers failed: ' . $result->get_error_message());
 
 			return array('result' => 'error');
 		}

--- a/src/NMM_Monero.php
+++ b/src/NMM_Monero.php
@@ -347,4 +347,54 @@ class NMM_Monero {
 			'transactions' => $transactions,
 		);
 	}
+
+	/**
+	 * All incoming transfers for account 0 in ONE wallet-RPC call, grouped by the
+	 * receiving subaddress. The cron uses this to check many unpaid Monero orders
+	 * per tick with a single get_transfers instead of two RPC calls
+	 * (get_address_index + get_transfers) per address. Returns
+	 * { result: 'success', by_address: { address => NMM_Transaction[] } } or
+	 * { result: 'error' } so callers can skip this tick without crediting anyone.
+	 */
+	public static function get_account_transactions() {
+		do_action('nmm_xmr_account_fetch');
+
+		$result = self::rpc('get_transfers', array(
+			'in' => true,
+			'pool' => true,
+			'account_index' => 0,
+		));
+
+		if (is_wp_error($result)) {
+			NMM_Util::log(__FILE__, __LINE__, 'XMR batch RPC failed: ' . $result->get_error_message());
+
+			return array('result' => 'error');
+		}
+
+		$byAddress = array();
+
+		foreach (array('in', 'pool') as $bucket) {
+			if (!isset($result->{$bucket}) || !is_array($result->{$bucket})) {
+				continue;
+			}
+
+			foreach ($result->{$bucket} as $transfer) {
+				if (!isset($transfer->address, $transfer->amount, $transfer->txid)) {
+					continue;
+				}
+
+				$byAddress[$transfer->address][] = new NMM_Transaction(
+					$transfer->amount,
+					isset($transfer->confirmations) ? (int) $transfer->confirmations : 0,
+					isset($transfer->timestamp) ? (int) $transfer->timestamp : time(),
+					$transfer->txid
+				);
+			}
+		}
+
+		return array(
+			'result' => 'success',
+			'by_address' => $byAddress,
+		);
+	}
 }

--- a/src/NMM_Payment.php
+++ b/src/NMM_Payment.php
@@ -67,7 +67,7 @@ class NMM_Payment {
 
 			if ($cryptoId === 'XMR') {
 				if (!$xmrFetched) {
-					$batch = NMM_Monero::get_account_transactions();
+					$batch = NMM_Monero::get_account_transactions($transactionLifetime);
 					$xmrByAddress = (isset($batch['result']) && $batch['result'] === 'success' && isset($batch['by_address']))
 						? $batch['by_address']
 						: array();

--- a/src/NMM_Payment.php
+++ b/src/NMM_Payment.php
@@ -6,6 +6,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class NMM_Payment {
 
+	// How far before an order's creation time a matching transaction may be dated
+	// and still be accepted, absorbing block-timestamp clock skew while rejecting
+	// genuinely pre-order transactions on reused addresses.
+	const TX_ORDER_SKEW_GRACE_SEC = 3600;
+
 	public static function check_all_addresses_for_matching_payment($transactionLifetime) {
 		$paymentRepo = new NMM_Payment_Repo();
 
@@ -13,6 +18,10 @@ class NMM_Payment {
 		// just to size the budget.
 		$total = $paymentRepo->count_distinct_unpaid_addresses();
 		if ($total < 1) {
+			// Nothing unpaid: drop any stale retry keys so they cannot linger.
+			if (get_option('nmm_autopay_scan_retry', array())) {
+				update_option('nmm_autopay_scan_retry', array(), false);
+			}
 			return;
 		}
 
@@ -46,17 +55,45 @@ class NMM_Payment {
 			$batch = array_merge($batch, $head);
 		}
 
+		// Re-check addresses whose fetch FAILED last tick BEFORE the fair sweep, so
+		// a transient explorer/RPC error is retried on the very next tick rather
+		// than waiting a whole sweep (by which time a payment could age out). The
+		// retry set is bounded, and only the fair-sweep batch advances the cursor.
+		$retrySet = get_option('nmm_autopay_scan_retry', array());
+		if (!is_array($retrySet)) {
+			$retrySet = array();
+		}
+
+		$toProcess = array();
+		$seen = array();
+		foreach ($retrySet as $key) {
+			$parts = explode('|', $key, 2);
+			if (count($parts) === 2 && !isset($seen[$key])) {
+				$toProcess[] = array('cryptocurrency' => $parts[0], 'address' => $parts[1]);
+				$seen[$key] = true;
+			}
+		}
+
+		$lastKey = $cursor;
+		foreach ($batch as $record) {
+			$key = self::scan_key($record);
+			$lastKey = $key; // the cursor tracks the fair sweep only, never retries
+			if (!isset($seen[$key])) {
+				$toProcess[] = $record;
+				$seen[$key] = true;
+			}
+		}
+
 		// For Monero, fetch the account's incoming transfers ONCE per tick and
 		// group them by subaddress locally, instead of two wallet-RPC calls
 		// (get_address_index + get_transfers) for every address.
 		$xmrFetched = false;
+		$xmrOk = false;
 		$xmrByAddress = array();
 
-		$lastKey = $cursor;
+		$newFailed = array();
 
-		foreach ($batch as $record) {
-			$lastKey = self::scan_key($record);
-
+		foreach ($toProcess as $record) {
 			$cryptoId = $record['cryptocurrency'];
 			$address = $record['address'];
 
@@ -70,20 +107,30 @@ class NMM_Payment {
 			if ($cryptoId === 'XMR') {
 				if (!$xmrFetched) {
 					$xmrBatch = NMM_Monero::get_account_transactions($effectiveLifetime);
-					$xmrByAddress = (isset($xmrBatch['result']) && $xmrBatch['result'] === 'success' && isset($xmrBatch['by_address']))
-						? $xmrBatch['by_address']
-						: array();
+					$xmrOk = (isset($xmrBatch['result']) && $xmrBatch['result'] === 'success');
+					$xmrByAddress = ($xmrOk && isset($xmrBatch['by_address'])) ? $xmrBatch['by_address'] : array();
 					$xmrFetched = true;
+				}
+				if (!$xmrOk) {
+					$newFailed[] = self::scan_key($record); // could not fetch; retry next tick
+					continue;
 				}
 				$xmrTxs = isset($xmrByAddress[$address]) ? $xmrByAddress[$address] : array();
 				self::process_address_transactions($crypto, $address, $xmrTxs, $effectiveLifetime);
 			}
 			else {
-				self::check_address_transactions_for_matching_payments($crypto, $address, $effectiveLifetime);
+				if (!self::check_address_transactions_for_matching_payments($crypto, $address, $effectiveLifetime)) {
+					$newFailed[] = self::scan_key($record);
+				}
 			}
 		}
 
-		// Persist where we stopped so the next tick continues fairly.
+		// Persist the bounded retry set and the fair-sweep cursor.
+		$newFailed = array_values(array_unique($newFailed));
+		if (count($newFailed) > 200) {
+			$newFailed = array_slice($newFailed, 0, 200);
+		}
+		update_option('nmm_autopay_scan_retry', $newFailed, false);
 		update_option('nmm_autopay_scan_cursor', $lastKey, false);
 	}
 
@@ -129,6 +176,9 @@ class NMM_Payment {
 		return $record['cryptocurrency'] . '|' . $record['address'];
 	}
 
+	// Returns true if the address's transactions were fetched (and matched), or
+	// false if the fetch failed - so the sweep can retry a transient failure on
+	// the next tick instead of leaving it until the whole backlog is swept again.
 	private static function check_address_transactions_for_matching_payments($crypto, $address, $transactionLifetime) {
 		$cryptoId = $crypto->get_id();
 
@@ -140,12 +190,14 @@ class NMM_Payment {
 		}
 		catch (\Exception $e) {
 			NMM_Util::log(__FILE__, __LINE__, 'Unable to get transactions for ' . $cryptoId);
-			return;
+			return false;
 		}
 
 		NMM_Util::log(__FILE__, __LINE__, 'Transcations found for ' . $cryptoId . ' - ' . $address . ': ' . print_r($transactions, true));
 
 		self::process_address_transactions($crypto, $address, $transactions, $transactionLifetime);
+
+		return true;
 	}
 
 	/**
@@ -196,6 +248,17 @@ class NMM_Payment {
 			$matchingPaymentRecords = [];
 
 			foreach ($paymentRecords as $record) {
+				// A transaction cannot pay an order that did not exist when it was
+				// made. On a reused static/carousel address an old, unconsumed
+				// transaction could otherwise complete a newly created order of the
+				// same amount - a risk the widened sweep window (which accepts ages
+				// beyond the base lifetime) would enlarge. Require the tx to be no
+				// older than the order, less a grace for block-timestamp clock skew.
+				$orderedAt = isset($record['ordered_at']) ? (int) $record['ordered_at'] : 0;
+				if ($orderedAt > 0 && $txTimeStamp < $orderedAt - self::TX_ORDER_SKEW_GRACE_SEC) {
+					continue;
+				}
+
 				$paymentAmount = $record['order_amount'];
 				$paymentAmountSmallestUnit = $paymentAmount * (10**$crypto->get_round_precision());
 

--- a/src/NMM_Payment.php
+++ b/src/NMM_Payment.php
@@ -6,22 +6,88 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class NMM_Payment {
 
-	public static function check_all_addresses_for_matching_payment($transactionLifetime) {		
+	public static function check_all_addresses_for_matching_payment($transactionLifetime) {
 		$paymentRepo = new NMM_Payment_Repo();
 
-		// get a unique list of unpaid "payments" to crypto addresses
+		// Unique unpaid payment addresses, in a stable order so the persisted
+		// sweep cursor below is meaningful across ticks.
 		$addressesToCheck = $paymentRepo->get_distinct_unpaid_addresses();
 
-		$cryptos = NMM_Cryptocurrencies::get();
+		if (empty($addressesToCheck)) {
+			return;
+		}
 
-		foreach ($addressesToCheck as $record) {
-			$address = $record['address'];
+		$cryptos = NMM_Cryptocurrencies::get();
+		$total = count($addressesToCheck);
+
+		// Bound the addresses checked per tick so a large backlog of abandoned,
+		// unpaid orders cannot hold the cron lock and starve payment, expiry, HD
+		// and Solana work. The persisted cursor makes the sweep fair: each tick
+		// resumes after the last address checked and wraps around, so every
+		// address is still checked within a few ticks.
+		$budget = (int) apply_filters('nmm_autopay_scan_budget', 50);
+		if ($budget < 1) {
+			$budget = 1;
+		}
+		$take = min($budget, $total);
+
+		// Resume after the address the previous tick stopped on. If that address
+		// is gone (paid or removed) the key is not found and we start at the top -
+		// still correct, just slightly less even for a single tick.
+		$cursor = get_option('nmm_autopay_scan_cursor', '');
+		$startIndex = 0;
+		foreach ($addressesToCheck as $i => $record) {
+			if (self::scan_key($record) === $cursor) {
+				$startIndex = $i + 1;
+				break;
+			}
+		}
+
+		// For Monero, fetch the account's incoming transfers ONCE per tick and
+		// group them by subaddress locally, instead of two wallet-RPC calls
+		// (get_address_index + get_transfers) for every address.
+		$xmrFetched = false;
+		$xmrByAddress = array();
+
+		$lastKey = $cursor;
+
+		for ($n = 0; $n < $take; $n++) {
+			$record = $addressesToCheck[($startIndex + $n) % $total];
+			$lastKey = self::scan_key($record);
 
 			$cryptoId = $record['cryptocurrency'];
+			$address = $record['address'];
+
+			if (!isset($cryptos[$cryptoId])) {
+				continue;
+			}
 			$crypto = $cryptos[$cryptoId];
 
-			self::check_address_transactions_for_matching_payments($crypto, $address, $transactionLifetime);
+			do_action('nmm_autopay_address_checked', $cryptoId, $address);
+
+			if ($cryptoId === 'XMR') {
+				if (!$xmrFetched) {
+					$batch = NMM_Monero::get_account_transactions();
+					$xmrByAddress = (isset($batch['result']) && $batch['result'] === 'success' && isset($batch['by_address']))
+						? $batch['by_address']
+						: array();
+					$xmrFetched = true;
+				}
+				$xmrTxs = isset($xmrByAddress[$address]) ? $xmrByAddress[$address] : array();
+				self::process_address_transactions($crypto, $address, $xmrTxs, $transactionLifetime);
+			}
+			else {
+				self::check_address_transactions_for_matching_payments($crypto, $address, $transactionLifetime);
+			}
 		}
+
+		// Persist where we stopped so the next tick continues fairly.
+		update_option('nmm_autopay_scan_cursor', $lastKey, false);
+	}
+
+	// Stable identity of a distinct-unpaid-address row, for the sweep cursor.
+	private static function scan_key($record) {
+		return $record['cryptocurrency'] . '|' . $record['address'];
 	}
 
 	private static function check_address_transactions_for_matching_payments($crypto, $address, $transactionLifetime) {

--- a/src/NMM_Payment.php
+++ b/src/NMM_Payment.php
@@ -18,27 +18,15 @@ class NMM_Payment {
 
 		$cryptos = NMM_Cryptocurrencies::get();
 
-		// Spread the per-tick work with a persisted cursor so a large backlog of
-		// abandoned, unpaid orders cannot hold the cron lock for one long tick and
-		// starve payment, expiry, HD and Solana work. The baseline budget keeps
-		// normal stores gentle on explorers.
+		// Size the per-tick budget and the effective matching window together (see
+		// scan_plan). The baseline budget keeps normal stores gentle on explorers;
+		// a large backlog raises it so the sweep stays fast; and the matching window
+		// is widened by the sweep period so a payment seen still-unconfirmed on one
+		// visit is not rejected as too old before its address next comes round.
 		$baseBudget = (int) apply_filters('nmm_autopay_scan_budget', 50);
-		if ($baseBudget < 1) {
-			$baseBudget = 1;
-		}
-
-		// Correctness floor on the budget: every address MUST be re-checked within
-		// the matching lifetime, or a payment that arrives just after its address
-		// is scanned would be older than $transactionLifetime when the address is
-		// finally revisited and would be rejected forever. So guarantee a full
-		// sweep within half the lifetime (2x margin for late cron runs), raising
-		// the budget above the baseline for a large backlog when necessary. The
-		// cron fires about once a minute (Action Scheduler / WP-Cron fallback).
-		$cronIntervalSec = 60;
-		$sweepTicks = max(1, (int) floor(max($cronIntervalSec, (int) $transactionLifetime / 2) / $cronIntervalSec));
-		$budget = max($baseBudget, (int) ceil($total / $sweepTicks));
-
-		$take = min($budget, $total);
+		$plan = self::scan_plan($total, $baseBudget, $transactionLifetime);
+		$take = $plan['take'];
+		$effectiveLifetime = $plan['effective_lifetime'];
 
 		// Keyset pagination around the persisted cursor: fetch only the budgeted
 		// slice ordered strictly AFTER the previous tick's stopping point, then
@@ -81,22 +69,59 @@ class NMM_Payment {
 
 			if ($cryptoId === 'XMR') {
 				if (!$xmrFetched) {
-					$xmrBatch = NMM_Monero::get_account_transactions($transactionLifetime);
+					$xmrBatch = NMM_Monero::get_account_transactions($effectiveLifetime);
 					$xmrByAddress = (isset($xmrBatch['result']) && $xmrBatch['result'] === 'success' && isset($xmrBatch['by_address']))
 						? $xmrBatch['by_address']
 						: array();
 					$xmrFetched = true;
 				}
 				$xmrTxs = isset($xmrByAddress[$address]) ? $xmrByAddress[$address] : array();
-				self::process_address_transactions($crypto, $address, $xmrTxs, $transactionLifetime);
+				self::process_address_transactions($crypto, $address, $xmrTxs, $effectiveLifetime);
 			}
 			else {
-				self::check_address_transactions_for_matching_payments($crypto, $address, $transactionLifetime);
+				self::check_address_transactions_for_matching_payments($crypto, $address, $effectiveLifetime);
 			}
 		}
 
 		// Persist where we stopped so the next tick continues fairly.
 		update_option('nmm_autopay_scan_cursor', $lastKey, false);
+	}
+
+	/**
+	 * Pure planner for one sweep tick. Given the distinct-unpaid backlog size, the
+	 * merchant baseline budget and the base matching lifetime, returns how many
+	 * addresses to check this tick ('take'/'budget') and the effective matching
+	 * lifetime to check them against ('effective_lifetime').
+	 *
+	 * A larger backlog raises the budget so a full sweep still completes within
+	 * about half the base lifetime (2x margin for late cron runs, ~1 tick/minute).
+	 * Spreading the sweep across ticks means an address is only revisited every
+	 * sweep period, so a payment that is still below its confirmation count on one
+	 * visit could age past the base lifetime before the next visit. Widening the
+	 * matching window by the actual sweep period closes that gap: any transaction
+	 * that confirms within the base lifetime is still matched on the next visit,
+	 * regardless of the (coin/config-dependent) confirmation delay. For a normal
+	 * store the sweep is ~1 tick, so the window is only nudged by a minute.
+	 */
+	public static function scan_plan($total, $baseBudget, $transactionLifetime, $cronIntervalSec = 60) {
+		$total = max(0, (int) $total);
+		$baseBudget = max(1, (int) $baseBudget);
+		$transactionLifetime = max(0, (int) $transactionLifetime);
+		$cronIntervalSec = max(1, (int) $cronIntervalSec);
+
+		$sweepTicks = max(1, (int) floor(max($cronIntervalSec, (int) ($transactionLifetime / 2)) / $cronIntervalSec));
+		$budget = max($baseBudget, (int) ceil($total / $sweepTicks));
+		$take = min($budget, $total);
+
+		// Actual ticks (and wall-clock seconds) to sweep the whole backlog at this
+		// budget - 1 tick for a small store, more for a large one.
+		$sweepPeriodSec = ($budget > 0 ? (int) ceil($total / $budget) : 1) * $cronIntervalSec;
+
+		return array(
+			'budget' => $budget,
+			'take' => $take,
+			'effective_lifetime' => $transactionLifetime + $sweepPeriodSec,
+		);
 	}
 
 	// Stable identity of a distinct-unpaid-address row, for the sweep cursor.

--- a/src/NMM_Payment.php
+++ b/src/NMM_Payment.php
@@ -26,6 +26,20 @@ class NMM_Payment {
 		}
 
 		$cryptos = NMM_Cryptocurrencies::get();
+		$nmmSettings = new NMM_Settings(get_option(NMM_REDUX_ID));
+
+		// The sweep must also finish before an order can be cancelled, or an order
+		// inserted just behind the cursor could reach cancel_expired_payments()
+		// (which runs the same tick) before its address is ever checked. Find the
+		// shortest cancellation window among the coins that actually have unpaid
+		// orders and let scan_plan keep the sweep inside it.
+		$shortestCancelSec = 0;
+		foreach ($paymentRepo->get_distinct_unpaid_cryptos() as $unpaidCryptoId) {
+			$winSec = (int) ((float) $nmmSettings->get_autopay_cancellation_time($unpaidCryptoId) * 3600);
+			if ($winSec > 0 && ($shortestCancelSec === 0 || $winSec < $shortestCancelSec)) {
+				$shortestCancelSec = $winSec;
+			}
+		}
 
 		// Size the per-tick budget and the effective matching window together (see
 		// scan_plan). The baseline budget keeps normal stores gentle on explorers;
@@ -33,7 +47,7 @@ class NMM_Payment {
 		// is widened by the sweep period so a payment seen still-unconfirmed on one
 		// visit is not rejected as too old before its address next comes round.
 		$baseBudget = (int) apply_filters('nmm_autopay_scan_budget', 50);
-		$plan = self::scan_plan($total, $baseBudget, $transactionLifetime);
+		$plan = self::scan_plan($total, $baseBudget, $transactionLifetime, $shortestCancelSec);
 		$take = $plan['take'];
 		$effectiveLifetime = $plan['effective_lifetime'];
 
@@ -141,22 +155,35 @@ class NMM_Payment {
 	 * lifetime to check them against ('effective_lifetime').
 	 *
 	 * A larger backlog raises the budget so a full sweep still completes within
-	 * about half the base lifetime (2x margin for late cron runs, ~1 tick/minute).
-	 * Spreading the sweep across ticks means an address is only revisited every
-	 * sweep period, so a payment that is still below its confirmation count on one
-	 * visit could age past the base lifetime before the next visit. Widening the
-	 * matching window by the actual sweep period closes that gap: any transaction
-	 * that confirms within the base lifetime is still matched on the next visit,
-	 * regardless of the (coin/config-dependent) confirmation delay. For a normal
-	 * store the sweep is ~1 tick, so the window is only nudged by a minute.
+	 * about half the base lifetime (2x margin for late cron runs, ~1 tick/minute)
+	 * AND within half the shortest cancellation window, so an order can never be
+	 * cancelled before its address is checked at least once. Spreading the sweep
+	 * across ticks means an address is only revisited every sweep period, so a
+	 * payment still below its confirmation count on one visit could age past the
+	 * base lifetime before the next visit. Widening the matching window by the
+	 * actual sweep period closes that gap: any transaction that confirms within
+	 * the base lifetime is still matched on the next visit, regardless of the
+	 * (coin/config-dependent) confirmation delay. For a normal store the sweep is
+	 * ~1 tick, so the window is only nudged by a minute.
+	 *
+	 * $shortestCancelSec is the shortest order-cancellation window among coins with
+	 * unpaid orders; pass 0 when unknown to fall back to the lifetime bound alone.
 	 */
-	public static function scan_plan($total, $baseBudget, $transactionLifetime, $cronIntervalSec = 60) {
+	public static function scan_plan($total, $baseBudget, $transactionLifetime, $shortestCancelSec = 0, $cronIntervalSec = 60) {
 		$total = max(0, (int) $total);
 		$baseBudget = max(1, (int) $baseBudget);
 		$transactionLifetime = max(0, (int) $transactionLifetime);
+		$shortestCancelSec = max(0, (int) $shortestCancelSec);
 		$cronIntervalSec = max(1, (int) $cronIntervalSec);
 
-		$sweepTicks = max(1, (int) floor(max($cronIntervalSec, (int) ($transactionLifetime / 2)) / $cronIntervalSec));
+		// Target a full sweep within half the base lifetime, tightened to half the
+		// shortest cancellation window when that is smaller.
+		$targetSweepSec = max($cronIntervalSec, (int) ($transactionLifetime / 2));
+		if ($shortestCancelSec > 0) {
+			$targetSweepSec = min($targetSweepSec, max($cronIntervalSec, (int) ($shortestCancelSec / 2)));
+		}
+
+		$sweepTicks = max(1, (int) floor($targetSweepSec / $cronIntervalSec));
 		$budget = max($baseBudget, (int) ceil($total / $sweepTicks));
 		$take = min($budget, $total);
 

--- a/src/NMM_Payment.php
+++ b/src/NMM_Payment.php
@@ -78,12 +78,25 @@ class NMM_Payment {
 			$retrySet = array();
 		}
 
-		$toProcess = array();
-		$seen = array();
+		// Parse retry keys, then keep only those whose payment is STILL unpaid: a
+		// row paid/cancelled/deleted while its explorer was down must not be
+		// re-queried forever (which would peg the failing endpoint and, at up to
+		// the 200-key cap, occupy the cron lock indefinitely).
+		$retryPairs = array();
 		foreach ($retrySet as $key) {
 			$parts = explode('|', $key, 2);
-			if (count($parts) === 2 && !isset($seen[$key])) {
-				$toProcess[] = array('cryptocurrency' => $parts[0], 'address' => $parts[1]);
+			if (count($parts) === 2) {
+				$retryPairs[] = array('cryptocurrency' => $parts[0], 'address' => $parts[1]);
+			}
+		}
+		$liveRetry = $paymentRepo->filter_unpaid_pairs($retryPairs);
+
+		$toProcess = array();
+		$seen = array();
+		foreach ($retryPairs as $pair) {
+			$key = $pair['cryptocurrency'] . '|' . $pair['address'];
+			if (isset($liveRetry[$key]) && !isset($seen[$key])) {
+				$toProcess[] = $pair;
 				$seen[$key] = true;
 			}
 		}

--- a/src/NMM_Payment.php
+++ b/src/NMM_Payment.php
@@ -20,15 +20,26 @@ class NMM_Payment {
 		$cryptos = NMM_Cryptocurrencies::get();
 		$total = count($addressesToCheck);
 
-		// Bound the addresses checked per tick so a large backlog of abandoned,
-		// unpaid orders cannot hold the cron lock and starve payment, expiry, HD
-		// and Solana work. The persisted cursor makes the sweep fair: each tick
-		// resumes after the last address checked and wraps around, so every
-		// address is still checked within a few ticks.
-		$budget = (int) apply_filters('nmm_autopay_scan_budget', 50);
-		if ($budget < 1) {
-			$budget = 1;
+		// Spread the per-tick work with a persisted cursor so a large backlog of
+		// abandoned, unpaid orders cannot hold the cron lock for one long tick and
+		// starve payment, expiry, HD and Solana work. The baseline budget keeps
+		// normal stores gentle on explorers.
+		$baseBudget = (int) apply_filters('nmm_autopay_scan_budget', 50);
+		if ($baseBudget < 1) {
+			$baseBudget = 1;
 		}
+
+		// Correctness floor on the budget: every address MUST be re-checked within
+		// the matching lifetime, or a payment that arrives just after its address
+		// is scanned would be older than $transactionLifetime when the address is
+		// finally revisited and would be rejected forever. So guarantee a full
+		// sweep within half the lifetime (2x margin for late cron runs), raising
+		// the budget above the baseline for a large backlog when necessary. The
+		// cron fires about once a minute (Action Scheduler / WP-Cron fallback).
+		$cronIntervalSec = 60;
+		$sweepTicks = max(1, (int) floor(max($cronIntervalSec, (int) $transactionLifetime / 2) / $cronIntervalSec));
+		$budget = max($baseBudget, (int) ceil($total / $sweepTicks));
+
 		$take = min($budget, $total);
 
 		// Resume after the address the previous tick stopped on. If that address

--- a/src/NMM_Payment.php
+++ b/src/NMM_Payment.php
@@ -9,16 +9,14 @@ class NMM_Payment {
 	public static function check_all_addresses_for_matching_payment($transactionLifetime) {
 		$paymentRepo = new NMM_Payment_Repo();
 
-		// Unique unpaid payment addresses, in a stable order so the persisted
-		// sweep cursor below is meaningful across ticks.
-		$addressesToCheck = $paymentRepo->get_distinct_unpaid_addresses();
-
-		if (empty($addressesToCheck)) {
+		// Count only (a single scalar) so a large backlog is never loaded into PHP
+		// just to size the budget.
+		$total = $paymentRepo->count_distinct_unpaid_addresses();
+		if ($total < 1) {
 			return;
 		}
 
 		$cryptos = NMM_Cryptocurrencies::get();
-		$total = count($addressesToCheck);
 
 		// Spread the per-tick work with a persisted cursor so a large backlog of
 		// abandoned, unpaid orders cannot hold the cron lock for one long tick and
@@ -42,24 +40,22 @@ class NMM_Payment {
 
 		$take = min($budget, $total);
 
-		// Resume at the first address ordered strictly AFTER the previous tick's
-		// stopping point. Matching by "next greater" rather than an exact key means
-		// that if that address was paid or removed between ticks, we still advance
-		// to the following one instead of restarting at index 0 (which, if the last
-		// scanned row is removed every tick, would rescan the top forever and
-		// starve later addresses). When the cursor is at/after the last row, no row
-		// is greater and we wrap to the top.
+		// Keyset pagination around the persisted cursor: fetch only the budgeted
+		// slice ordered strictly AFTER the previous tick's stopping point, then
+		// wrap to the head if that page ran off the end. Because we ask for rows
+		// "greater than" the cursor (not an exact key), a cursor row paid/removed
+		// between ticks simply advances to the next one - no restart-at-top that
+		// could starve later addresses. With $take <= $total the after/head pages
+		// never overlap, so no address is processed twice in a tick.
 		$cursor = get_option('nmm_autopay_scan_cursor', '');
 		$cursorParts = ($cursor !== '') ? explode('|', $cursor, 2) : array('', '');
 		$cursorCrypto = $cursorParts[0];
 		$cursorAddress = isset($cursorParts[1]) ? $cursorParts[1] : '';
 
-		$startIndex = 0;
-		foreach ($addressesToCheck as $i => $record) {
-			if (self::record_sorts_after($record, $cursorCrypto, $cursorAddress)) {
-				$startIndex = $i;
-				break;
-			}
+		$batch = $paymentRepo->get_unpaid_addresses_after($cursorCrypto, $cursorAddress, $take);
+		if (count($batch) < $take) {
+			$head = $paymentRepo->get_unpaid_addresses_from_start($take - count($batch));
+			$batch = array_merge($batch, $head);
 		}
 
 		// For Monero, fetch the account's incoming transfers ONCE per tick and
@@ -70,8 +66,7 @@ class NMM_Payment {
 
 		$lastKey = $cursor;
 
-		for ($n = 0; $n < $take; $n++) {
-			$record = $addressesToCheck[($startIndex + $n) % $total];
+		foreach ($batch as $record) {
 			$lastKey = self::scan_key($record);
 
 			$cryptoId = $record['cryptocurrency'];
@@ -86,9 +81,9 @@ class NMM_Payment {
 
 			if ($cryptoId === 'XMR') {
 				if (!$xmrFetched) {
-					$batch = NMM_Monero::get_account_transactions($transactionLifetime);
-					$xmrByAddress = (isset($batch['result']) && $batch['result'] === 'success' && isset($batch['by_address']))
-						? $batch['by_address']
+					$xmrBatch = NMM_Monero::get_account_transactions($transactionLifetime);
+					$xmrByAddress = (isset($xmrBatch['result']) && $xmrBatch['result'] === 'success' && isset($xmrBatch['by_address']))
+						? $xmrBatch['by_address']
 						: array();
 					$xmrFetched = true;
 				}
@@ -107,18 +102,6 @@ class NMM_Payment {
 	// Stable identity of a distinct-unpaid-address row, for the sweep cursor.
 	private static function scan_key($record) {
 		return $record['cryptocurrency'] . '|' . $record['address'];
-	}
-
-	// True if $record sorts strictly after the (cryptocurrency, address) cursor,
-	// matching get_distinct_unpaid_addresses()' ORDER BY cryptocurrency, address.
-	// An empty cursor sorts before everything, so the first row qualifies.
-	private static function record_sorts_after($record, $cursorCrypto, $cursorAddress) {
-		$cryptoCmp = strcmp($record['cryptocurrency'], $cursorCrypto);
-		if ($cryptoCmp !== 0) {
-			return $cryptoCmp > 0;
-		}
-
-		return strcmp($record['address'], $cursorAddress) > 0;
 	}
 
 	private static function check_address_transactions_for_matching_payments($crypto, $address, $transactionLifetime) {

--- a/src/NMM_Payment.php
+++ b/src/NMM_Payment.php
@@ -42,14 +42,22 @@ class NMM_Payment {
 
 		$take = min($budget, $total);
 
-		// Resume after the address the previous tick stopped on. If that address
-		// is gone (paid or removed) the key is not found and we start at the top -
-		// still correct, just slightly less even for a single tick.
+		// Resume at the first address ordered strictly AFTER the previous tick's
+		// stopping point. Matching by "next greater" rather than an exact key means
+		// that if that address was paid or removed between ticks, we still advance
+		// to the following one instead of restarting at index 0 (which, if the last
+		// scanned row is removed every tick, would rescan the top forever and
+		// starve later addresses). When the cursor is at/after the last row, no row
+		// is greater and we wrap to the top.
 		$cursor = get_option('nmm_autopay_scan_cursor', '');
+		$cursorParts = ($cursor !== '') ? explode('|', $cursor, 2) : array('', '');
+		$cursorCrypto = $cursorParts[0];
+		$cursorAddress = isset($cursorParts[1]) ? $cursorParts[1] : '';
+
 		$startIndex = 0;
 		foreach ($addressesToCheck as $i => $record) {
-			if (self::scan_key($record) === $cursor) {
-				$startIndex = $i + 1;
+			if (self::record_sorts_after($record, $cursorCrypto, $cursorAddress)) {
+				$startIndex = $i;
 				break;
 			}
 		}
@@ -99,6 +107,18 @@ class NMM_Payment {
 	// Stable identity of a distinct-unpaid-address row, for the sweep cursor.
 	private static function scan_key($record) {
 		return $record['cryptocurrency'] . '|' . $record['address'];
+	}
+
+	// True if $record sorts strictly after the (cryptocurrency, address) cursor,
+	// matching get_distinct_unpaid_addresses()' ORDER BY cryptocurrency, address.
+	// An empty cursor sorts before everything, so the first row qualifies.
+	private static function record_sorts_after($record, $cursorCrypto, $cursorAddress) {
+		$cryptoCmp = strcmp($record['cryptocurrency'], $cursorCrypto);
+		if ($cryptoCmp !== 0) {
+			return $cryptoCmp > 0;
+		}
+
+		return strcmp($record['address'], $cursorAddress) > 0;
 	}
 
 	private static function check_address_transactions_for_matching_payments($crypto, $address, $transactionLifetime) {

--- a/src/NMM_Payment_Repo.php
+++ b/src/NMM_Payment_Repo.php
@@ -66,13 +66,23 @@ class NMM_Payment_Repo {
 	public function get_distinct_unpaid_addresses() {
 		global $wpdb;
 
-		// Stable ordering so the cron's persisted fair-sweep cursor is meaningful
-		// across ticks (see NMM_Payment::check_all_addresses_for_matching_payment).
-		// BINARY makes the sort byte-wise so it matches the PHP strcmp() the cursor
-		// resume logic uses, regardless of the column's (case-insensitive) collation.
-		$query = "SELECT DISTINCT `address`, `cryptocurrency` FROM `$this->tableName` WHERE `status` = 'unpaid' ORDER BY BINARY `cryptocurrency`, BINARY `address`";
+		$results = $wpdb->get_results("SELECT DISTINCT `address`, `cryptocurrency` FROM `$this->tableName` WHERE `status` = 'unpaid'", ARRAY_A);
 
-		$results = $wpdb->get_results($query, ARRAY_A);
+		if (!is_array($results)) {
+			return array();
+		}
+
+		// Sort in PHP, byte-wise, so the order the cron's persisted fair-sweep
+		// cursor relies on exactly matches the strcmp() comparison it resumes with
+		// (see NMM_Payment::check_all_addresses_for_matching_payment). Doing it here
+		// rather than in SQL avoids two traps: an `ORDER BY BINARY <expr>` not in
+		// the SELECT DISTINCT list is rejected by MySQL 8 (error 3065), and a
+		// collation-dependent SQL sort would not match the cursor comparison anyway.
+		usort($results, function ($a, $b) {
+			$cryptoCmp = strcmp($a['cryptocurrency'], $b['cryptocurrency']);
+
+			return $cryptoCmp !== 0 ? $cryptoCmp : strcmp($a['address'], $b['address']);
+		});
 
 		return $results;
 	}

--- a/src/NMM_Payment_Repo.php
+++ b/src/NMM_Payment_Repo.php
@@ -63,28 +63,54 @@ class NMM_Payment_Repo {
 		return $wpdb->get_col("SELECT DISTINCT `cryptocurrency` FROM `$this->tableName` WHERE `status` = 'unpaid'");
 	}
 
-	public function get_distinct_unpaid_addresses() {
+	// Number of distinct unpaid (cryptocurrency, address) pairs. A single scalar,
+	// so the cron can size its per-tick budget without loading the whole backlog
+	// into PHP.
+	public function count_distinct_unpaid_addresses() {
 		global $wpdb;
 
-		$results = $wpdb->get_results("SELECT DISTINCT `address`, `cryptocurrency` FROM `$this->tableName` WHERE `status` = 'unpaid'", ARRAY_A);
+		return (int) $wpdb->get_var("SELECT COUNT(*) FROM (SELECT DISTINCT `cryptocurrency`, `address` FROM `$this->tableName` WHERE `status` = 'unpaid') t");
+	}
 
-		if (!is_array($results)) {
-			return array();
-		}
+	/**
+	 * One budgeted page of distinct unpaid (cryptocurrency, address) rows, ordered
+	 * by (cryptocurrency, address), starting strictly AFTER the given cursor
+	 * (keyset pagination). Only $limit rows are read, so a large backlog never
+	 * loads or sorts in full each tick; the (status, cryptocurrency, address)
+	 * index serves both the range and the ordering. ORDER BY columns are in the
+	 * SELECT DISTINCT list (MySQL 8 safe), and the keyset comparison uses the same
+	 * collation as the sort so pages never skip or repeat a row. An empty cursor
+	 * ('' / '') sorts before everything and returns the first page.
+	 */
+	public function get_unpaid_addresses_after($cursorCrypto, $cursorAddress, $limit) {
+		global $wpdb;
+		$limit = max(1, (int) $limit);
 
-		// Sort in PHP, byte-wise, so the order the cron's persisted fair-sweep
-		// cursor relies on exactly matches the strcmp() comparison it resumes with
-		// (see NMM_Payment::check_all_addresses_for_matching_payment). Doing it here
-		// rather than in SQL avoids two traps: an `ORDER BY BINARY <expr>` not in
-		// the SELECT DISTINCT list is rejected by MySQL 8 (error 3065), and a
-		// collation-dependent SQL sort would not match the cursor comparison anyway.
-		usort($results, function ($a, $b) {
-			$cryptoCmp = strcmp($a['cryptocurrency'], $b['cryptocurrency']);
+		return $wpdb->get_results($wpdb->prepare(
+			"SELECT DISTINCT `cryptocurrency`, `address`
+			 FROM `$this->tableName`
+			 WHERE `status` = 'unpaid'
+			 AND (`cryptocurrency` > %s OR (`cryptocurrency` = %s AND `address` > %s))
+			 ORDER BY `cryptocurrency`, `address`
+			 LIMIT %d",
+			$cursorCrypto, $cursorCrypto, $cursorAddress, $limit
+		), ARRAY_A);
+	}
 
-			return $cryptoCmp !== 0 ? $cryptoCmp : strcmp($a['address'], $b['address']);
-		});
+	// The first $limit distinct unpaid (cryptocurrency, address) rows in order, to
+	// wrap the sweep back to the top when a page runs off the end of the list.
+	public function get_unpaid_addresses_from_start($limit) {
+		global $wpdb;
+		$limit = max(1, (int) $limit);
 
-		return $results;
+		return $wpdb->get_results($wpdb->prepare(
+			"SELECT DISTINCT `cryptocurrency`, `address`
+			 FROM `$this->tableName`
+			 WHERE `status` = 'unpaid'
+			 ORDER BY `cryptocurrency`, `address`
+			 LIMIT %d",
+			$limit
+		), ARRAY_A);
 	}
 
 	public function get_unpaid_for_address($cryptoId, $address) {

--- a/src/NMM_Payment_Repo.php
+++ b/src/NMM_Payment_Repo.php
@@ -68,7 +68,9 @@ class NMM_Payment_Repo {
 
 		// Stable ordering so the cron's persisted fair-sweep cursor is meaningful
 		// across ticks (see NMM_Payment::check_all_addresses_for_matching_payment).
-		$query = "SELECT DISTINCT `address`, `cryptocurrency` FROM `$this->tableName` WHERE `status` = 'unpaid' ORDER BY `cryptocurrency`, `address`";
+		// BINARY makes the sort byte-wise so it matches the PHP strcmp() the cursor
+		// resume logic uses, regardless of the column's (case-insensitive) collation.
+		$query = "SELECT DISTINCT `address`, `cryptocurrency` FROM `$this->tableName` WHERE `status` = 'unpaid' ORDER BY BINARY `cryptocurrency`, BINARY `address`";
 
 		$results = $wpdb->get_results($query, ARRAY_A);
 

--- a/src/NMM_Payment_Repo.php
+++ b/src/NMM_Payment_Repo.php
@@ -113,6 +113,41 @@ class NMM_Payment_Repo {
 		), ARRAY_A);
 	}
 
+	/**
+	 * Given a bounded list of ['cryptocurrency'=>.., 'address'=>..] pairs, return
+	 * the subset that still has an unpaid row, as a set keyed by "crypto|address".
+	 * One indexed query for the whole list, so the cron can drop failed-fetch
+	 * retries whose order was since paid/cancelled/deleted without re-querying a
+	 * dead address forever.
+	 */
+	public function filter_unpaid_pairs($pairs) {
+		global $wpdb;
+
+		if (empty($pairs) || !is_array($pairs)) {
+			return array();
+		}
+
+		$clauses = array();
+		$args = array();
+		foreach ($pairs as $pair) {
+			$clauses[] = '(`cryptocurrency` = %s AND `address` = %s)';
+			$args[] = $pair['cryptocurrency'];
+			$args[] = $pair['address'];
+		}
+
+		$sql = "SELECT DISTINCT `cryptocurrency`, `address` FROM `$this->tableName` WHERE `status` = 'unpaid' AND (" . implode(' OR ', $clauses) . ")";
+		$rows = $wpdb->get_results($wpdb->prepare($sql, $args), ARRAY_A);
+
+		$live = array();
+		if (is_array($rows)) {
+			foreach ($rows as $row) {
+				$live[$row['cryptocurrency'] . '|' . $row['address']] = true;
+			}
+		}
+
+		return $live;
+	}
+
 	public function get_unpaid_for_address($cryptoId, $address) {
 		global $wpdb;
 

--- a/src/NMM_Payment_Repo.php
+++ b/src/NMM_Payment_Repo.php
@@ -66,7 +66,9 @@ class NMM_Payment_Repo {
 	public function get_distinct_unpaid_addresses() {
 		global $wpdb;
 
-		$query = "SELECT DISTINCT `address`, `cryptocurrency` FROM `$this->tableName` WHERE `status` = 'unpaid'";
+		// Stable ordering so the cron's persisted fair-sweep cursor is meaningful
+		// across ticks (see NMM_Payment::check_all_addresses_for_matching_payment).
+		$query = "SELECT DISTINCT `address`, `cryptocurrency` FROM `$this->tableName` WHERE `status` = 'unpaid' ORDER BY `cryptocurrency`, `address`";
 
 		$results = $wpdb->get_results($query, ARRAY_A);
 

--- a/src/NMM_Util.php
+++ b/src/NMM_Util.php
@@ -74,14 +74,17 @@ class NMM_Util {
 		return extension_loaded('gmp') || extension_loaded('bcmath');
 	}
 
-	// Per-order advisory lock name. Scoped to this database AND this order so a
-	// site sharing a MySQL server does not block another, and distinct orders
-	// never share a lock. DB_NAME is hashed to a fixed length so a long database
-	// name can never push the (variable-length) order id past MySQL's 64-char
-	// lock-name limit - which would silently truncate and let two DIFFERENT
-	// orders collide on one lock.
+	// Per-order advisory lock name. Scoped to this site AND this order so distinct
+	// orders never share a lock, and neither do same-numbered orders on different
+	// sites. The table prefix ($wpdb->prefix) is blog-specific on multisite, where
+	// sites share DB_NAME and WooCommerce order ids can overlap; DB_NAME still
+	// separates sites that merely share a MySQL server. Both are hashed to a fixed
+	// length so they can never push the (variable-length) order id past MySQL's
+	// 64-char lock-name limit - which would truncate and collide DIFFERENT orders.
 	private static function order_init_lock_name($orderId) {
-		return 'nmm_oinit_' . (int) $orderId . '_' . substr(md5(DB_NAME), 0, 12);
+		global $wpdb;
+
+		return 'nmm_oinit_' . (int) $orderId . '_' . substr(md5(DB_NAME . '|' . $wpdb->prefix), 0, 12);
 	}
 
 	/**

--- a/src/NMM_Util.php
+++ b/src/NMM_Util.php
@@ -74,6 +74,37 @@ class NMM_Util {
 		return extension_loaded('gmp') || extension_loaded('bcmath');
 	}
 
+	// Per-order advisory lock name. Scoped to this database AND this order so a
+	// site sharing a MySQL server does not block another, and distinct orders
+	// never share a lock. DB_NAME is hashed to a fixed length so a long database
+	// name can never push the (variable-length) order id past MySQL's 64-char
+	// lock-name limit - which would silently truncate and let two DIFFERENT
+	// orders collide on one lock.
+	private static function order_init_lock_name($orderId) {
+		return 'nmm_oinit_' . (int) $orderId . '_' . substr(md5(DB_NAME), 0, 12);
+	}
+
+	/**
+	 * Acquire the per-order initialization lock so two concurrent first loads of
+	 * the thank-you page cannot both allocate a payment address for one order.
+	 * GET_LOCK is atomic across connections, owned by the acquiring connection,
+	 * and released automatically if that PHP process dies, so a crash can never
+	 * wedge it. Returns the raw GET_LOCK result: '1' acquired, '0' timed out,
+	 * null if advisory locks are unavailable on this host. The caller must call
+	 * release_order_init_lock() only when this returned '1'.
+	 */
+	public static function acquire_order_init_lock($orderId, $timeoutSeconds = 15) {
+		global $wpdb;
+
+		return $wpdb->get_var($wpdb->prepare('SELECT GET_LOCK(%s, %d)', self::order_init_lock_name($orderId), $timeoutSeconds));
+	}
+
+	public static function release_order_init_lock($orderId) {
+		global $wpdb;
+
+		$wpdb->query($wpdb->prepare('SELECT RELEASE_LOCK(%s)', self::order_init_lock_name($orderId)));
+	}
+
 }
 
 ?>

--- a/tests/test-autopay-cancel.php
+++ b/tests/test-autopay-cancel.php
@@ -251,5 +251,23 @@ $tx2 = new NMM_Transaction($txUnits, 999, time(), 'TXFRESHe2e');
 NMM_Payment::process_address_transactions($btc, $reuseAddr, array($tx2), $lifetime);
 aok('control: fresh tx DOES pay a new order',   rec_status($wpdb,$pt,$oC) === 'paid');
 
+// Order-relative lower bound: a transaction dated well before the order existed
+// (a stray tx on a reused address) must NOT complete it, even when the matching
+// window is wide enough by age. A tx dated at/after the order still pays it.
+$wpdb->query($wpdb->prepare("DELETE FROM `$pt` WHERE address=%s", $reuseAddr));
+delete_option('nmmpro_BTC_transactions_consumed_for_' . $reuseAddr);
+$oOrd = mkorder('pending');
+$ordTime = time();
+$wpdb->query($wpdb->prepare(
+	"INSERT INTO `$pt` (address,cryptocurrency,status,ordered_at,order_id,order_amount,hd_address) VALUES (%s,'BTC','unpaid',%d,%d,%s,0)",
+	$reuseAddr, $ordTime, $oOrd, $reuseAmt));
+$wideLife = 6 * 3600; // wide, so age is not the reason for any rejection
+$preTx = new NMM_Transaction($txUnits, 999, $ordTime - 2 * 3600, 'TXPREORDER'); // 2h before the order
+NMM_Payment::process_address_transactions($btc, $reuseAddr, array($preTx), $wideLife);
+aok('pre-order tx does NOT pay the order',      rec_status($wpdb,$pt,$oOrd) === 'unpaid', 'status=' . rec_status($wpdb,$pt,$oOrd));
+$postTx = new NMM_Transaction($txUnits, 999, $ordTime + 60, 'TXPOSTORDER'); // just after the order
+NMM_Payment::process_address_transactions($btc, $reuseAddr, array($postTx), $wideLife);
+aok('post-order tx DOES pay the order',         rec_status($wpdb,$pt,$oOrd) === 'paid', 'status=' . rec_status($wpdb,$pt,$oOrd));
+
 $wpdb->query("DELETE FROM `$pt`");
 echo $GLOBALS['ac_ok'] ? "\nAUTOPAY-CANCEL CHECKS PASSED\n" : "\nAUTOPAY-CANCEL CHECKS FAILED\n";

--- a/tests/test-autopay-scan.php
+++ b/tests/test-autopay-scan.php
@@ -33,6 +33,15 @@ for ($i = 0; $i < $N; $i++) {
 }
 $wpdb->query("INSERT INTO `$pt` (address,cryptocurrency,status,ordered_at,order_id,order_amount,hd_address) VALUES " . implode(',', $rows));
 
+// DB retrieval must itself be bounded: the count is a single scalar and each
+// keyset page returns only its LIMIT, never the whole backlog.
+$repo0 = new NMM_Payment_Repo();
+sok('count_distinct is a scalar over backlog', $repo0->count_distinct_unpaid_addresses() === $N, 'count=' . $repo0->count_distinct_unpaid_addresses());
+sok('keyset after-cursor returns only LIMIT',  count($repo0->get_unpaid_addresses_after('', '', $budget)) === $budget, 'rows=' . count($repo0->get_unpaid_addresses_after('', '', $budget)));
+sok('keyset from-start returns only LIMIT',    count($repo0->get_unpaid_addresses_from_start(7)) === 7);
+$afterMid = $repo0->get_unpaid_addresses_after('XMR', 'xmraddr_049', $budget);
+sok('keyset resumes strictly after the cursor', isset($afterMid[0]) && $afterMid[0]['address'] === 'xmraddr_050', 'first=' . (isset($afterMid[0]) ? $afterMid[0]['address'] : '(none)'));
+
 add_filter('nmm_autopay_scan_budget', function () use ($budget) { return $budget; });
 
 $GLOBALS['as_checked'] = array();

--- a/tests/test-autopay-scan.php
+++ b/tests/test-autopay-scan.php
@@ -26,13 +26,19 @@ function sok($label, $cond, $extra = '') { printf("%-56s %s%s\n", $label, $cond 
 // window nudged one tick; a large backlog raises the budget AND widens the
 // matching window by the sweep period so a payment can't age out unseen between
 // two far-apart visits (3h lifetime, ~1 tick/min, sweep target = lifetime/2).
-$planSmall = NMM_Payment::scan_plan(50, 50, 3 * 3600);
+$dayCancel = 24 * 3600; // default cancellation window; lifetime bound governs
+$planSmall = NMM_Payment::scan_plan(50, 50, 3 * 3600, $dayCancel);
 sok('scan_plan small: budget stays baseline',   $planSmall['budget'] === 50, 'budget=' . $planSmall['budget']);
 sok('scan_plan small: window = base + 1 tick',  $planSmall['effective_lifetime'] === 10860, 'eff=' . $planSmall['effective_lifetime']);
-$planBig = NMM_Payment::scan_plan(9000, 50, 3 * 3600);
+$planBig = NMM_Payment::scan_plan(9000, 50, 3 * 3600, $dayCancel);
 sok('scan_plan big: budget scales up',          $planBig['budget'] === 100, 'budget=' . $planBig['budget']);
 sok('scan_plan big: window widened by sweep',   $planBig['effective_lifetime'] === 16200, 'eff=' . $planBig['effective_lifetime']);
 sok('scan_plan big: window exceeds base life',  $planBig['effective_lifetime'] > 3 * 3600);
+// A short (1h) cancellation window tightens the sweep so no order can expire
+// before its first check: target = 30min => 30 ticks => budget = ceil(9000/30) = 300.
+$planCancel = NMM_Payment::scan_plan(9000, 50, 3 * 3600, 3600);
+sok('scan_plan: short cancel window raises budget', $planCancel['budget'] === 300, 'budget=' . $planCancel['budget']);
+sok('scan_plan: sweep window <= half cancel window', ($planCancel['effective_lifetime'] - 3 * 3600) <= 1800, 'sweep=' . ($planCancel['effective_lifetime'] - 3 * 3600));
 
 // Seed N unpaid Monero addresses. XMR RPC is unconfigured in CI, so the batch
 // fetch returns an error (no network) and no order is ever matched - the unpaid

--- a/tests/test-autopay-scan.php
+++ b/tests/test-autopay-scan.php
@@ -45,6 +45,10 @@ for ($i = 0; $i < $N; $i++) {
 }
 $wpdb->query("INSERT INTO `$pt` (address,cryptocurrency,status,ordered_at,order_id,order_amount,hd_address) VALUES " . implode(',', $rows));
 
+// Make the Monero batch fetch "succeed" (empty) via the seam so the budget/cursor
+// assertions below are not perturbed by failed-fetch retries (exercised separately).
+add_filter('nmm_xmr_account_transactions', function () { return array('result' => 'success', 'by_address' => array()); });
+
 // DB retrieval must itself be bounded: the count is a single scalar and each
 // keyset page returns only its LIMIT, never the whole backlog.
 $repo0 = new NMM_Payment_Repo();
@@ -159,10 +163,43 @@ for ($t = 1; $t < 5; $t++) {
 }
 sok('adaptive: full sweep within the lifetime window', count($adaptiveCovered) === $bigN, 'covered=' . count($adaptiveCovered) . '/' . $bigN);
 
+// Failed fetches are retried on the NEXT tick, not left until a whole sweep
+// later. With the Monero batch fetch forced to error, addresses checked this
+// tick are retained in a bounded retry set and re-checked immediately next tick.
+remove_all_filters('nmm_xmr_account_transactions');
+add_filter('nmm_xmr_account_transactions', function () { return array('result' => 'error'); });
+remove_all_filters('nmm_autopay_scan_budget');
+add_filter('nmm_autopay_scan_budget', function () { return 3; });
+$wpdb->query("DELETE FROM `$pt`");
+delete_option('nmm_autopay_scan_cursor');
+delete_option('nmm_autopay_scan_retry');
+for ($i = 0; $i < 9; $i++) {
+	$wpdb->query($wpdb->prepare("INSERT INTO `$pt` (address,cryptocurrency,status,ordered_at,order_id,order_amount,hd_address) VALUES (%s,'XMR','unpaid',%d,%d,'0.00100000',0)", sprintf('xmrf_%d', $i), time(), 740000 + $i));
+}
+
+$GLOBALS['as_checked'] = array();
+NMM_Payment::check_all_addresses_for_matching_payment(3 * 3600); // tick 1: xmrf_0,1,2 all fail
+sok('failed fetches recorded in retry set',     count(get_option('nmm_autopay_scan_retry', array())) === 3, 'retry=' . count(get_option('nmm_autopay_scan_retry', array())));
+
+$GLOBALS['as_checked'] = array();
+NMM_Payment::check_all_addresses_for_matching_payment(3 * 3600); // tick 2: retries 0,1,2 + sweeps 3,4,5
+$tick2 = $GLOBALS['as_checked'];
+sok('failed keys re-checked the very next tick', in_array('xmrf_0', $tick2, true) && in_array('xmrf_1', $tick2, true) && in_array('xmrf_2', $tick2, true), 'tick2=' . implode(',', $tick2));
+sok('retry set stays bounded',                  count(get_option('nmm_autopay_scan_retry', array())) <= 9);
+
+// Once fetches succeed again, the retry set drains.
+remove_all_filters('nmm_xmr_account_transactions');
+add_filter('nmm_xmr_account_transactions', function () { return array('result' => 'success', 'by_address' => array()); });
+NMM_Payment::check_all_addresses_for_matching_payment(3 * 3600);
+NMM_Payment::check_all_addresses_for_matching_payment(3 * 3600);
+sok('retry set drains after fetches succeed',    count(get_option('nmm_autopay_scan_retry', array())) === 0, 'retry=' . count(get_option('nmm_autopay_scan_retry', array())));
+
+remove_all_filters('nmm_xmr_account_transactions');
 remove_all_filters('nmm_autopay_scan_budget');
 remove_all_actions('nmm_autopay_address_checked');
 remove_all_actions('nmm_xmr_account_fetch');
 $wpdb->query("DELETE FROM `$pt`");
 delete_option('nmm_autopay_scan_cursor');
+delete_option('nmm_autopay_scan_retry');
 
 echo $GLOBALS['as_ok'] ? "\nAUTOPAY-SCAN CHECKS PASSED\n" : "\nAUTOPAY-SCAN CHECKS FAILED\n";

--- a/tests/test-autopay-scan.php
+++ b/tests/test-autopay-scan.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Live-DB test: NMM_Payment::check_all_addresses_for_matching_payment() must
+ * bound the addresses it checks per cron tick, do at most one Monero wallet-RPC
+ * fetch per tick regardless of how many XMR addresses are pending, and still
+ * cover every address within a few ticks via a persisted fair cursor. Requires
+ * WordPress + WooCommerce + a database. Skips cleanly standalone.
+ *
+ *   Run:  wp eval-file tests/test-autopay-scan.php
+ */
+
+if (!isset($GLOBALS['wpdb']) || !is_object($GLOBALS['wpdb']) || !function_exists('wc_create_order')) {
+	echo "test-autopay-scan: skipped (needs WordPress + WooCommerce + DB)\n";
+	return;
+}
+
+$wpdb = $GLOBALS['wpdb'];
+$pt = $wpdb->prefix . NMM_PAYMENT_TABLE;
+$wpdb->query("DELETE FROM `$pt`");
+delete_option('nmm_autopay_scan_cursor');
+
+$GLOBALS['as_ok'] = true;
+function sok($label, $cond, $extra = '') { printf("%-56s %s%s\n", $label, $cond ? 'ok' : 'FAIL', $extra !== '' ? "  $extra" : ''); if (!$cond) { $GLOBALS['as_ok'] = false; } }
+
+// Seed N unpaid Monero addresses. XMR RPC is unconfigured in CI, so the batch
+// fetch returns an error (no network) and no order is ever matched - the unpaid
+// set stays at N across ticks, which is exactly what we want for a coverage test.
+$N = 100;
+$budget = 30;
+$rows = array();
+for ($i = 0; $i < $N; $i++) {
+	$rows[] = $wpdb->prepare("('xmraddr_%03d','XMR','unpaid',%d,%d,'0.00100000',0)", $i, time(), 700000 + $i);
+}
+$wpdb->query("INSERT INTO `$pt` (address,cryptocurrency,status,ordered_at,order_id,order_amount,hd_address) VALUES " . implode(',', $rows));
+
+add_filter('nmm_autopay_scan_budget', function () use ($budget) { return $budget; });
+
+$GLOBALS['as_checked'] = array();
+$GLOBALS['as_fetches'] = 0;
+add_action('nmm_autopay_address_checked', function ($cryptoId, $address) { $GLOBALS['as_checked'][] = $address; }, 10, 2);
+add_action('nmm_xmr_account_fetch', function () { $GLOBALS['as_fetches']++; });
+
+$lifetime = 3 * 60 * 60;
+$ticksNeeded = (int) ceil($N / $budget); // 4
+$perTickCounts = array();
+$perTickFetches = array();
+$covered = array();
+$firstAddrPerTick = array();
+
+for ($t = 0; $t < $ticksNeeded; $t++) {
+	$GLOBALS['as_checked'] = array();
+	$GLOBALS['as_fetches'] = 0;
+
+	NMM_Payment::check_all_addresses_for_matching_payment($lifetime);
+
+	$perTickCounts[] = count($GLOBALS['as_checked']);
+	$perTickFetches[] = $GLOBALS['as_fetches'];
+	$firstAddrPerTick[] = isset($GLOBALS['as_checked'][0]) ? $GLOBALS['as_checked'][0] : '(none)';
+	foreach ($GLOBALS['as_checked'] as $a) { $covered[$a] = true; }
+}
+
+sok('each tick checks exactly the budget',        array_unique($perTickCounts) === array($budget), 'counts=' . implode(',', $perTickCounts));
+sok('each tick does exactly ONE XMR fetch',       array_unique($perTickFetches) === array(1), 'fetches=' . implode(',', $perTickFetches));
+sok('cursor advances (ticks start elsewhere)',    count(array_unique($firstAddrPerTick)) === $ticksNeeded, 'firsts=' . implode(',', $firstAddrPerTick));
+sok('all N addresses covered within ceil(N/b)',   count($covered) === $N, 'covered=' . count($covered) . '/' . $N);
+sok('sweep cursor persisted',                     get_option('nmm_autopay_scan_cursor', '') !== '');
+
+// Budget larger than the backlog: single tick covers everything, still one fetch.
+$wpdb->query("DELETE FROM `$pt`");
+delete_option('nmm_autopay_scan_cursor');
+$small = array();
+for ($i = 0; $i < 5; $i++) { $small[] = $wpdb->prepare("('xmrsmall_%d','XMR','unpaid',%d,%d,'0.00100000',0)", $i, time(), 710000 + $i); }
+$wpdb->query("INSERT INTO `$pt` (address,cryptocurrency,status,ordered_at,order_id,order_amount,hd_address) VALUES " . implode(',', $small));
+$GLOBALS['as_checked'] = array();
+$GLOBALS['as_fetches'] = 0;
+NMM_Payment::check_all_addresses_for_matching_payment($lifetime);
+sok('small backlog: checks all in one tick',      count($GLOBALS['as_checked']) === 5, 'checked=' . count($GLOBALS['as_checked']));
+sok('small backlog: still one XMR fetch',         $GLOBALS['as_fetches'] === 1, 'fetches=' . $GLOBALS['as_fetches']);
+
+// Empty backlog: no fetch, no work, no crash.
+$wpdb->query("DELETE FROM `$pt`");
+$GLOBALS['as_checked'] = array();
+$GLOBALS['as_fetches'] = 0;
+NMM_Payment::check_all_addresses_for_matching_payment($lifetime);
+sok('empty backlog: no addresses checked',        count($GLOBALS['as_checked']) === 0);
+sok('empty backlog: no XMR fetch',                $GLOBALS['as_fetches'] === 0);
+
+remove_all_filters('nmm_autopay_scan_budget');
+remove_all_actions('nmm_autopay_address_checked');
+remove_all_actions('nmm_xmr_account_fetch');
+$wpdb->query("DELETE FROM `$pt`");
+delete_option('nmm_autopay_scan_cursor');
+
+echo $GLOBALS['as_ok'] ? "\nAUTOPAY-SCAN CHECKS PASSED\n" : "\nAUTOPAY-SCAN CHECKS FAILED\n";

--- a/tests/test-autopay-scan.php
+++ b/tests/test-autopay-scan.php
@@ -85,6 +85,35 @@ NMM_Payment::check_all_addresses_for_matching_payment($lifetime);
 sok('empty backlog: no addresses checked',        count($GLOBALS['as_checked']) === 0);
 sok('empty backlog: no XMR fetch',                $GLOBALS['as_fetches'] === 0);
 
+// Adaptive budget: when the backlog is large enough that a full sweep at the
+// baseline would exceed the matching lifetime, the budget rises so every address
+// is still re-checked within the lifetime - otherwise a payment arriving just
+// after its address was scanned would be older than the lifetime when revisited
+// and rejected forever. Baseline 10, lifetime 600s -> sweepTicks = floor(300/60)
+// = 5, so budget = max(10, ceil(100/5)) = 20.
+remove_all_filters('nmm_autopay_scan_budget');
+add_filter('nmm_autopay_scan_budget', function () { return 10; });
+$wpdb->query("DELETE FROM `$pt`");
+delete_option('nmm_autopay_scan_cursor');
+$bigN = 100;
+$bigRows = array();
+for ($i = 0; $i < $bigN; $i++) { $bigRows[] = $wpdb->prepare("('xmrbig_%03d','XMR','unpaid',%d,%d,'0.00100000',0)", $i, time(), 720000 + $i); }
+$wpdb->query("INSERT INTO `$pt` (address,cryptocurrency,status,ordered_at,order_id,order_amount,hd_address) VALUES " . implode(',', $bigRows));
+
+$shortLifetime = 600; // 10 minutes
+$GLOBALS['as_checked'] = array();
+NMM_Payment::check_all_addresses_for_matching_payment($shortLifetime);
+sok('budget rises above baseline to cover lifetime', count($GLOBALS['as_checked']) === 20, 'per-tick=' . count($GLOBALS['as_checked']) . ' (baseline 10)');
+
+$adaptiveCovered = array();
+foreach ($GLOBALS['as_checked'] as $a) { $adaptiveCovered[$a] = true; }
+for ($t = 1; $t < 5; $t++) {
+	$GLOBALS['as_checked'] = array();
+	NMM_Payment::check_all_addresses_for_matching_payment($shortLifetime);
+	foreach ($GLOBALS['as_checked'] as $a) { $adaptiveCovered[$a] = true; }
+}
+sok('adaptive: full sweep within the lifetime window', count($adaptiveCovered) === $bigN, 'covered=' . count($adaptiveCovered) . '/' . $bigN);
+
 remove_all_filters('nmm_autopay_scan_budget');
 remove_all_actions('nmm_autopay_address_checked');
 remove_all_actions('nmm_xmr_account_fetch');

--- a/tests/test-autopay-scan.php
+++ b/tests/test-autopay-scan.php
@@ -22,6 +22,18 @@ delete_option('nmm_autopay_scan_cursor');
 $GLOBALS['as_ok'] = true;
 function sok($label, $cond, $extra = '') { printf("%-56s %s%s\n", $label, $cond ? 'ok' : 'FAIL', $extra !== '' ? "  $extra" : ''); if (!$cond) { $GLOBALS['as_ok'] = false; } }
 
+// scan_plan (pure): budget/window sizing. Small store stays at baseline with the
+// window nudged one tick; a large backlog raises the budget AND widens the
+// matching window by the sweep period so a payment can't age out unseen between
+// two far-apart visits (3h lifetime, ~1 tick/min, sweep target = lifetime/2).
+$planSmall = NMM_Payment::scan_plan(50, 50, 3 * 3600);
+sok('scan_plan small: budget stays baseline',   $planSmall['budget'] === 50, 'budget=' . $planSmall['budget']);
+sok('scan_plan small: window = base + 1 tick',  $planSmall['effective_lifetime'] === 10860, 'eff=' . $planSmall['effective_lifetime']);
+$planBig = NMM_Payment::scan_plan(9000, 50, 3 * 3600);
+sok('scan_plan big: budget scales up',          $planBig['budget'] === 100, 'budget=' . $planBig['budget']);
+sok('scan_plan big: window widened by sweep',   $planBig['effective_lifetime'] === 16200, 'eff=' . $planBig['effective_lifetime']);
+sok('scan_plan big: window exceeds base life',  $planBig['effective_lifetime'] > 3 * 3600);
+
 // Seed N unpaid Monero addresses. XMR RPC is unconfigured in CI, so the batch
 // fetch returns an error (no network) and no order is ever matched - the unpaid
 // set stays at N across ticks, which is exactly what we want for a coverage test.

--- a/tests/test-autopay-scan.php
+++ b/tests/test-autopay-scan.php
@@ -85,6 +85,30 @@ NMM_Payment::check_all_addresses_for_matching_payment($lifetime);
 sok('empty backlog: no addresses checked',        count($GLOBALS['as_checked']) === 0);
 sok('empty backlog: no XMR fetch',                $GLOBALS['as_fetches'] === 0);
 
+// Cursor resilience: when the row the cursor points at is removed between ticks
+// (its order got paid), the sweep must resume at the NEXT address, not restart at
+// the top. Otherwise removing the last-scanned row every tick would rescan the
+// beginning forever and starve later addresses past the matching window.
+remove_all_filters('nmm_autopay_scan_budget');
+add_filter('nmm_autopay_scan_budget', function () { return 3; });
+$wpdb->query("DELETE FROM `$pt`");
+delete_option('nmm_autopay_scan_cursor');
+for ($i = 0; $i < 9; $i++) {
+	$wpdb->query($wpdb->prepare("INSERT INTO `$pt` (address,cryptocurrency,status,ordered_at,order_id,order_amount,hd_address) VALUES (%s,'XMR','unpaid',%d,%d,'0.00100000',0)", sprintf('xmrc_%d', $i), time(), 730000 + $i));
+}
+
+$GLOBALS['as_checked'] = array();
+NMM_Payment::check_all_addresses_for_matching_payment(3 * 3600); // tick 1 -> xmrc_0,1,2
+$tick1 = $GLOBALS['as_checked'];
+$lastScanned = end($tick1);
+$wpdb->query($wpdb->prepare("DELETE FROM `$pt` WHERE address=%s", $lastScanned)); // as if it got paid
+
+$GLOBALS['as_checked'] = array();
+NMM_Payment::check_all_addresses_for_matching_payment(3 * 3600); // tick 2
+$tick2 = $GLOBALS['as_checked'];
+sok('resumes after a removed cursor row',       isset($tick2[0]) && $tick2[0] === 'xmrc_3', 'tick2 first=' . (isset($tick2[0]) ? $tick2[0] : '(none)') . ', removed=' . $lastScanned);
+sok('does not restart at the top',              !in_array('xmrc_0', $tick2, true), 'tick2=' . implode(',', $tick2));
+
 // Adaptive budget: when the backlog is large enough that a full sweep at the
 // baseline would exceed the matching lifetime, the budget rises so every address
 // is still re-checked within the lifetime - otherwise a payment arriving just

--- a/tests/test-autopay-scan.php
+++ b/tests/test-autopay-scan.php
@@ -193,6 +193,15 @@ $tick2 = $GLOBALS['as_checked'];
 sok('failed keys re-checked the very next tick', in_array('xmrf_0', $tick2, true) && in_array('xmrf_1', $tick2, true) && in_array('xmrf_2', $tick2, true), 'tick2=' . implode(',', $tick2));
 sok('retry set stays bounded',                  count(get_option('nmm_autopay_scan_retry', array())) <= 9);
 
+// A retry key whose payment is no longer unpaid (paid/cancelled/deleted while the
+// endpoint stays down) must be dropped, not queried forever.
+$retryNow = get_option('nmm_autopay_scan_retry', array());
+$goneKey = $retryNow[0]; // e.g. 'XMR|xmrf_0'
+$goneParts = explode('|', $goneKey, 2);
+$wpdb->query($wpdb->prepare("DELETE FROM `$pt` WHERE address=%s", $goneParts[1])); // as if paid/removed
+NMM_Payment::check_all_addresses_for_matching_payment(3 * 3600); // still failing fetches
+sok('stale retry key dropped once not unpaid',  !in_array($goneKey, get_option('nmm_autopay_scan_retry', array()), true), 'gone=' . $goneKey);
+
 // Once fetches succeed again, the retry set drains.
 remove_all_filters('nmm_xmr_account_transactions');
 add_filter('nmm_xmr_account_transactions', function () { return array('result' => 'success', 'by_address' => array()); });

--- a/tests/test-monero-url.php
+++ b/tests/test-monero-url.php
@@ -73,6 +73,13 @@ mok('ipv6 loopback: ip preserved',        is_array($v6Loop) && $v6Loop['ip'] ===
 mok('resolve entry ipv4 plain',   NMM_Monero::curl_resolve_entry('wallet.example.com', 443, '93.184.216.34') === 'wallet.example.com:443:93.184.216.34');
 mok('resolve entry ipv6 bracketed', NMM_Monero::curl_resolve_entry('wallet.example.com', 18082, '2001:db8::1') === 'wallet.example.com:18082:[2001:db8::1]');
 
+// lookback_min_height bounds the batch get_transfers to the payment window so an
+// established wallet's full history is never fetched: ~120s/block, 2x window + 30.
+mok('min_height 3h window (90 blk *2 +30)', NMM_Monero::lookback_min_height(1000000, 3 * 3600) === 1000000 - 210);
+mok('min_height clamps at 0 near genesis',  NMM_Monero::lookback_min_height(50, 3 * 3600) === 0);
+mok('min_height zero lifetime = height-30', NMM_Monero::lookback_min_height(1000, 0) === 970);
+mok('min_height is bounded (not full hist)', NMM_Monero::lookback_min_height(5000000, 3 * 3600) === 4999790);
+
 // --- plan_request: transport must never resolve away from the vetted address ---
 // plan($target, $hasCurl, $canPin, $hasCreds)
 function plan($target, $curl, $canPin, $creds) { return NMM_Monero::plan_request($target, $curl, $canPin, $creds); }

--- a/tests/test-order-init-lock.php
+++ b/tests/test-order-init-lock.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Live-DB test: the per-order initialization lock (NMM_Util::acquire/release_
+ * order_init_lock) serializes two concurrent first loads of the thank-you page
+ * so they cannot both allocate a payment address for the same order, and is
+ * scoped per order so distinct orders never block each other. Also checks that
+ * the payment table's UNIQUE(order_id, order_amount) constraint keeps exactly
+ * one payment record per order even if a second worker slipped through.
+ * Requires WordPress + a database. Skips cleanly standalone.
+ *
+ *   Run:  wp eval-file tests/test-order-init-lock.php
+ */
+
+if (!isset($GLOBALS['wpdb']) || !is_object($GLOBALS['wpdb'])) {
+	echo "test-order-init-lock: skipped (needs WordPress + DB)\n";
+	return;
+}
+
+$wpdb = $GLOBALS['wpdb'];
+$pt = $wpdb->prefix . NMM_PAYMENT_TABLE;
+
+$GLOBALS['ol_ok'] = true;
+function lok($label, $cond, $extra = '') { printf("%-56s %s%s\n", $label, $cond ? 'ok' : 'FAIL', $extra !== '' ? "  $extra" : ''); if (!$cond) { $GLOBALS['ol_ok'] = false; } }
+
+$orderA = 8100001;
+$orderB = 8100002;
+
+// A second, independent DB connection to stand in for a concurrent request:
+// GET_LOCK is owned per-connection, so a lock held on $wpdb2 blocks the main
+// connection exactly as two PHP workers would contend.
+$wpdb2 = new wpdb(DB_USER, DB_PASSWORD, DB_NAME, DB_HOST);
+$wpdb2->suppress_errors(true);
+$main = $GLOBALS['wpdb'];
+
+// Worker A (connection 2) acquires the init lock for order A.
+$GLOBALS['wpdb'] = $wpdb2;
+$aHeld = NMM_Util::acquire_order_init_lock($orderA, 0);
+$GLOBALS['wpdb'] = $main;
+lok('worker A acquires order-init lock',        $aHeld === '1', 'got=' . var_export($aHeld, true));
+
+// Worker B (main connection) must NOT get the same order's lock (0s timeout).
+$bSameOrder = NMM_Util::acquire_order_init_lock($orderA, 0);
+lok('worker B blocked on the SAME order',       $bSameOrder === '0', 'got=' . var_export($bSameOrder, true));
+
+// A different order is independently lockable - scoping works, no false sharing.
+$bOtherOrder = NMM_Util::acquire_order_init_lock($orderB, 0);
+lok('a DIFFERENT order is not blocked',         $bOtherOrder === '1', 'got=' . var_export($bOtherOrder, true));
+if ($bOtherOrder === '1') { NMM_Util::release_order_init_lock($orderB); }
+
+// A releases; the same order becomes lockable again.
+$GLOBALS['wpdb'] = $wpdb2;
+NMM_Util::release_order_init_lock($orderA);
+$GLOBALS['wpdb'] = $main;
+$bAfterRelease = NMM_Util::acquire_order_init_lock($orderA, 0);
+lok('same order lockable after A releases',     $bAfterRelease === '1', 'got=' . var_export($bAfterRelease, true));
+if ($bAfterRelease === '1') { NMM_Util::release_order_init_lock($orderA); }
+
+// The lock name must be order-specific even if DB_NAME is long: two different
+// orders must never collide on one truncated 64-char lock name. Prove it by
+// holding both at once on connection 2.
+$GLOBALS['wpdb'] = $wpdb2;
+$h1 = NMM_Util::acquire_order_init_lock($orderA, 0);
+$h2 = NMM_Util::acquire_order_init_lock($orderB, 0);
+lok('two distinct orders hold locks at once',   $h1 === '1' && $h2 === '1', "$h1,$h2");
+NMM_Util::release_order_init_lock($orderA);
+NMM_Util::release_order_init_lock($orderB);
+$GLOBALS['wpdb'] = $main;
+
+// Even if two workers both reached the insert, UNIQUE(order_id, order_amount)
+// permits only one payment record for the order - so there can never be two
+// competing monitored rows for one order+amount.
+if (defined('NMM_PAYMENT_TABLE')) {
+	$wpdb->query($wpdb->prepare("DELETE FROM `$pt` WHERE order_id=%d", $orderA));
+	$repo = new NMM_Payment_Repo();
+	$repo->insert('addr_worker_A', 'BTC', $orderA, '0.00100000', 'unpaid');
+	$wpdb->suppress_errors(true);
+	$repo->insert('addr_worker_B', 'BTC', $orderA, '0.00100000', 'unpaid'); // duplicate order+amount
+	$wpdb->suppress_errors(false);
+	$count = (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM `$pt` WHERE order_id=%d AND order_amount='0.00100000'", $orderA));
+	$addr = $wpdb->get_var($wpdb->prepare("SELECT address FROM `$pt` WHERE order_id=%d", $orderA));
+	lok('exactly one payment row for the order',    $count === 1, 'count=' . $count);
+	lok('the first worker\'s address is the one kept', $addr === 'addr_worker_A', 'addr=' . $addr);
+	$wpdb->query($wpdb->prepare("DELETE FROM `$pt` WHERE order_id=%d", $orderA));
+}
+
+$wpdb2->close();
+
+echo $GLOBALS['ol_ok'] ? "\nORDER-INIT-LOCK CHECKS PASSED\n" : "\nORDER-INIT-LOCK CHECKS FAILED\n";

--- a/tests/test-order-init-lock.php
+++ b/tests/test-order-init-lock.php
@@ -103,4 +103,27 @@ if (defined('NMM_PAYMENT_TABLE')) {
 
 $wpdb2->close();
 
+// Post-lock recheck must see a wallet_address committed by another worker after
+// this request first read the order (which caches an empty value). The gateway
+// forces a fresh meta read under the lock; assert that a forced re-read reflects
+// a value written behind a previously-read order object's back.
+if (function_exists('wc_create_order')) {
+	$o = wc_create_order();
+	$o->save();
+	$oid = $o->get_id();
+
+	$staleOrder = wc_get_order($oid);
+	$staleOrder->get_meta('wallet_address'); // populate this object's meta cache (empty)
+
+	// Simulate the lock holder committing the address via a separate load.
+	$holder = wc_get_order($oid);
+	$holder->update_meta_data('wallet_address', 'ADDR_FROM_HOLDER');
+	$holder->save();
+
+	$staleOrder->read_meta_data(true); // exactly what the gateway does post-lock
+	lok('forced re-read sees the committed address', $staleOrder->get_meta('wallet_address') === 'ADDR_FROM_HOLDER', 'got=' . $staleOrder->get_meta('wallet_address'));
+
+	$holder->delete(true);
+}
+
 echo $GLOBALS['ol_ok'] ? "\nORDER-INIT-LOCK CHECKS PASSED\n" : "\nORDER-INIT-LOCK CHECKS FAILED\n";

--- a/tests/test-order-init-lock.php
+++ b/tests/test-order-init-lock.php
@@ -31,6 +31,10 @@ $orderB = 8100002;
 $wpdb2 = new wpdb(DB_USER, DB_PASSWORD, DB_NAME, DB_HOST);
 $wpdb2->suppress_errors(true);
 $main = $GLOBALS['wpdb'];
+// Two concurrent requests on the SAME site share the table prefix; a fresh wpdb
+// does not initialize it, so mirror the main connection's so the per-site lock
+// name matches (the lock is scoped by DB_NAME + prefix).
+$wpdb2->prefix = $main->prefix;
 
 // Worker A (connection 2) acquires the init lock for order A.
 $GLOBALS['wpdb'] = $wpdb2;
@@ -54,6 +58,20 @@ $GLOBALS['wpdb'] = $main;
 $bAfterRelease = NMM_Util::acquire_order_init_lock($orderA, 0);
 lok('same order lockable after A releases',     $bAfterRelease === '1', 'got=' . var_export($bAfterRelease, true));
 if ($bAfterRelease === '1') { NMM_Util::release_order_init_lock($orderA); }
+
+// Multisite scoping: the SAME order id on a DIFFERENT site (different table
+// prefix) must NOT contend - those are unrelated orders that merely share
+// DB_NAME and an id. The main site holds order A; a second site's request for
+// "order A" should acquire freely.
+$mainHold = NMM_Util::acquire_order_init_lock($orderA, 0);
+$wpdb2->prefix = $main->prefix . 's2_'; // pretend a second network site
+$GLOBALS['wpdb'] = $wpdb2;
+$site2 = NMM_Util::acquire_order_init_lock($orderA, 0);
+if ($site2 === '1') { NMM_Util::release_order_init_lock($orderA); }
+$GLOBALS['wpdb'] = $main;
+$wpdb2->prefix = $main->prefix; // restore for the remaining checks
+lok('same order id on a DIFFERENT site is free', $mainHold === '1' && $site2 === '1', "$mainHold,$site2");
+if ($mainHold === '1') { NMM_Util::release_order_init_lock($orderA); }
 
 // The lock name must be order-specific even if DB_NAME is long: two different
 // orders must never collide on one truncated 64-char lock name. Prove it by


### PR DESCRIPTION
Maintenance release addressing two findings from external review of v2.9.4.

**[P1] Concurrency-safe thank-you payment initialization.** Two near-simultaneous first loads of the same order could both pass the empty-`wallet_address` check and each allocate a different address (Monero subaddress / carousel), leaving the displayed address different from the monitored payment row. Initialization now runs under a per-order MySQL advisory lock (`NMM_Util::acquire/release_order_init_lock`, same crash-safe GET_LOCK primitive the cron uses) with a re-fetch + re-check after acquiring, so exactly one address is allocated and the meta always matches the payment record.

**[P2] Bounded Autopay address scan.** The verifier checked every unpaid address per tick with no limit (and 2 wallet-RPC calls per Monero address), so a large abandonment backlog could hold the cron lock and starve payment/expiry/HD/Solana work. Now: a per-tick budget (`nmm_autopay_scan_budget`, default 50), a persisted fair sweep cursor for eventual coverage, and a single Monero `get_transfers` per tick grouped by subaddress locally.

**Tests (WP+WooCommerce+MariaDB, wired into CI):**
- `test-order-init-lock.php` — cross-connection lock mutual exclusion, per-order scoping, release, no name-truncation collision, one payment row per order.
- `test-autopay-scan.php` — 100 unpaid XMR addresses / budget 30: each tick checks exactly the budget, does exactly one Monero fetch, advances the cursor, covers all within ceil(N/budget) ticks; plus small/empty backlog.

Verified: full local suite green, full-repo `php -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)