### PR TITLE
2.9.5: concurrency-safe thank-you payment initialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,3 +137,9 @@ jobs:
           echo "$OUT"
           echo "$OUT" | grep -qi "skipped" && { echo "::error::autopay test skipped"; exit 1; } || true
           echo "$OUT" | grep -q "AUTOPAY-CANCEL CHECKS PASSED" || { echo "::error::autopay test did not pass"; exit 1; }
+      - name: Per-order initialization lock test (must run, not skip)
+        run: |
+          OUT=$(wp eval-file "$GITHUB_WORKSPACE/plugin/tests/test-order-init-lock.php" --path=wp 2>&1)
+          echo "$OUT"
+          echo "$OUT" | grep -qi "skipped" && { echo "::error::order-init-lock test skipped"; exit 1; } || true
+          echo "$OUT" | grep -q "ORDER-INIT-LOCK CHECKS PASSED" || { echo "::error::order-init-lock test did not pass"; exit 1; }

--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Requires at least: 5.0
 Tested up to: 7.0
 Requires PHP: 7.4
 License: GPL v3
-Stable Tag: 2.9.4
+Stable Tag: 2.9.5
 
 Absolutely the easiest setup in the industry. No registration. No API keys. No middleman. Accept bitcoin, ethereum, litecoin, and more.
 
@@ -182,6 +182,9 @@ Yes. Filters are available for redirecting verification requests, customizing th
 Yes - as a safeguard. Privacy Mode derives a fresh address per order from your master public key. To avoid handing out an ever-growing range of addresses, the plugin returns an address to the pool for reuse **only** if the order was abandoned without paying and fresh block-explorer checks confirm the address never received anything on-chain; any address that saw funds is retired permanently. This keeps a run of abandoned checkouts from advancing the derivation index unnecessarily. As defense-in-depth, set your receiving wallet's **gap limit** (the number of consecutive unused addresses it scans from the seed - 20 by default in Electrum) comfortably above the longest run of abandoned checkouts you would expect between payments, so a paid address is always discovered on seed recovery. In Electrum this is `wallet.change_gap_limit` / the `gap_limit_for_change` and address gap-limit settings; other HD wallets have an equivalent. This wallet setting should be a backstop, not the plugin's primary protection.
 
 == Changelog ==
+
+= 2.9.5 =
+* Autopay/Privacy Mode: the thank-you page now allocates a payment address under an order-scoped database lock and re-reads the order after acquiring it, so two near-simultaneous first loads of the same order can no longer each allocate a different address (most visible with Monero subaddresses and carousel addresses) - exactly one address is assigned, and the address shown to the customer is always the one being monitored. If a second request finds the order already being set up it shows a brief "preparing your payment details" notice instead of allocating, and a failed set-up is recorded before the lock is released so it can never overwrite a concurrent success
 
 = 2.9.4 =
 * Autopay: the background job no longer cancels an order that was paid (by the merchant, a webhook, or the verifier) after its unpaid record was read but before cancellation - it re-checks the live order and reconciles the payment record instead. This is the Autopay counterpart of the HD-address cancellation fix in 2.9.3

--- a/nomiddleman-crypto-woocommerce.php
+++ b/nomiddleman-crypto-woocommerce.php
@@ -7,7 +7,7 @@ Plugin URI:  https://wordpress.org/plugins/nomiddleman-crypto-payments-for-wooco
 Description: WooCommerce Bitcoin and Cryptocurrency Payment Gateway
 Author: nomiddleman
 Author URI: https://github.com/rmwb/nomiddleman-woocommerce
-Version: 2.9.4
+Version: 2.9.5
 Requires PHP: 7.4
 Text Domain: nomiddleman-crypto-payments-for-woocommerce
 Domain Path: /languages
@@ -71,7 +71,7 @@ function NMM_init_gateways(){
     define('NMM_PLUGIN_FILE', __FILE__);
     define('NMM_ABS_PATH', dirname(NMM_PLUGIN_FILE));
 
-    define('NMM_VERSION', '2.9.4');
+    define('NMM_VERSION', '2.9.5');
     
     define('NMM_REDUX_SLUG', 'nmmpro_options');
 

--- a/src/NMM_Gateway.php
+++ b/src/NMM_Gateway.php
@@ -243,6 +243,17 @@ class NMM_Gateway extends WC_Payment_Gateway {
             // order while we still hold the lock (see the catch below).
             $initializing = true;
 
+            // Reaching here means the order has no wallet_address, so it was never
+            // initialized successfully - yet an earlier attempt may have inserted
+            // an Autopay payment row and then failed before persisting the meta.
+            // Clear those unpaid leftovers under the lock: otherwise
+            // UNIQUE(order_id, order_amount) would silently reject this attempt's
+            // insert, leaving the previous attempt's address monitored while we
+            // show the customer a different, unwatched one. Paid/cancelled rows
+            // are real records and are never touched.
+            $staleRepo = new NMM_Payment_Repo();
+            $staleRepo->delete_unpaid_for_order($order_id);
+
             $nmmSettings = new NMM_Settings(get_option(NMM_REDUX_ID));
 
             $chosenCryptoId = $order->get_meta('nmm_chosen_crypto_id');

--- a/src/NMM_Gateway.php
+++ b/src/NMM_Gateway.php
@@ -185,32 +185,63 @@ class NMM_Gateway extends WC_Payment_Gateway {
         
         try {
             $order = wc_get_order($order_id);
-            $existingWalletAddress = $order->get_meta('wallet_address');
 
-            // if we already set this then we are on a page refresh, so handle refresh
-            if (!empty($existingWalletAddress)) {
-
-                if ($order->is_paid()) {
-                    echo '<p class="nmm-status-paid">' . esc_html__('Payment received - thank you! Your order is being processed.', 'nomiddleman-crypto-payments-for-woocommerce') . '</p>';
-                    return;
-                }
-
-                // Do not re-display payment instructions for an order that is no
-                // longer awaiting payment. Its address may have been recycled to
-                // a different order, so a late payment would credit someone else.
-                if ($order->has_status(array('cancelled', 'failed'))) {
-                    echo '<p class="nmm-status-cancelled">' . esc_html__('This order is no longer awaiting payment. Please do not send any funds to the address shown previously. If you believe this is an error, contact the store.', 'nomiddleman-crypto-payments-for-woocommerce') . '</p>';
-                    return;
-                }
-
-                $this->handle_thank_you_refresh(
-                    $order->get_meta('crypto_type_id'),
-                    $existingWalletAddress,
-                    $order->get_meta('crypto_amount'),
-                    $order_id);
-
+            // Fast path: the address is already allocated (a page refresh). No
+            // lock is needed just to re-display it.
+            if (!empty($order->get_meta('wallet_address'))) {
+                $this->display_existing_payment($order, $order_id);
                 return;
             }
+
+            // First load. Serialize per-order initialization so two near-
+            // simultaneous first loads of the same order cannot both allocate an
+            // address: with Monero subaddresses or carousel addresses each worker
+            // would mint a DIFFERENT address, and the last meta write could differ
+            // from the address recorded in the payment table, leaving the
+            // displayed address unmonitored. Uses the same crash-safe MySQL
+            // advisory lock the cron uses.
+            $lockResult = NMM_Util::acquire_order_init_lock($order_id);
+            $initializing = false; // becomes true once we commit to allocating
+
+            try {
+                // Re-fetch under the lock: another worker may have finished
+                // initializing while we waited for it. If so, just display that
+                // address and never allocate a second one. Force a fresh meta read
+                // (bypassing the request-local cache the pre-lock get_meta() above
+                // populated with an empty wallet_address) so we actually see what
+                // the worker that held the lock just committed - a stale cache here
+                // would let us allocate a second, unmonitored address.
+                $order = wc_get_order($order_id);
+                if ($order) {
+                    $order->read_meta_data(true);
+                }
+                if ($order && !empty($order->get_meta('wallet_address'))) {
+                    $this->display_existing_payment($order, $order_id);
+                    return;
+                }
+
+                if ($lockResult === '0') {
+                    // The lock works and another request holds it: that request is
+                    // still initializing this order (a slow first load - exchange
+                    // rate or wallet RPC). We must NOT allocate a second address -
+                    // that is exactly the race this lock prevents. Ask the customer
+                    // to refresh; the fast path above will then show the address the
+                    // other request assigns.
+                    NMM_Util::log(__FILE__, __LINE__, 'Order-init lock busy for order ' . $order_id . '; another request is still initializing. Asking the customer to refresh.', 'warning');
+                    echo '<p class="nmm-status-pending">' . esc_html__('We are preparing your payment details. This will be ready in a few seconds - please refresh this page.', 'nomiddleman-crypto-payments-for-woocommerce') . '</p>';
+                    return;
+                }
+
+                if ($lockResult !== '1') {
+                    // null: advisory locks are unavailable on this host. Degrade to
+                    // initializing without overlap protection (matching the pre-lock
+                    // behaviour) rather than never allocating an address at all.
+                    NMM_Util::log(__FILE__, __LINE__, 'Advisory locks unavailable on this host; initializing order ' . $order_id . ' without overlap protection.', 'warning');
+                }
+
+            // From here we are allocating; a throw past this point must fail the
+            // order while we still hold the lock (see the catch below).
+            $initializing = true;
 
             $nmmSettings = new NMM_Settings(get_option(NMM_REDUX_ID));
 
@@ -334,23 +365,79 @@ class NMM_Gateway extends WC_Payment_Gateway {
 
             // Output additional thank you page html
             $this->output_thank_you_html($crypto, $orderWalletAddress, $formattedCryptoTotal, $order_id);
+            }
+            catch ( \Exception $e ) {
+                // Initialization failed. Mark the order failed HERE, while we still
+                // hold the lock, so a concurrent first-load request that is waiting
+                // cannot acquire the lock, allocate a fresh address, reach on-hold,
+                // and then have this delayed failure overwrite it - which would
+                // leave a monitored payment address on a failed order. Only fail if
+                // we had actually begun allocating ($initializing); an error while
+                // re-displaying an already-initialized order must not fail it.
+                if ($initializing) {
+                    $failedOrder = wc_get_order($order_id);
+                    if ($failedOrder) {
+                        /* translators: %s: error message */
+                        $failedOrder->update_status('wc-failed', sprintf(__('Error Message: %s', 'nomiddleman-crypto-payments-for-woocommerce'), $e->getMessage()));
+                    }
+                }
+                NMM_Util::log(__FILE__, __LINE__, 'Something went wrong during checkout: ' . $e->getMessage());
+                $this->render_checkout_error($e->getMessage());
+            }
+            finally {
+                // Release only the lock we actually acquired ('1'); on '0'/null we
+                // never held it. Runs on the normal path, on an early return above,
+                // and AFTER the failure handling above - so the lock covers the
+                // whole of initialization and its error handling together.
+                if ($lockResult === '1') {
+                    NMM_Util::release_order_init_lock($order_id);
+                }
+            }
         }
         catch ( \Exception $e ) {
-            $order = wc_get_order($order_id);
-
-            // cancel order if something went wrong
-            /* translators: %s: error message */
-            $order->update_status('wc-failed', sprintf(__('Error Message: %s', 'nomiddleman-crypto-payments-for-woocommerce'), $e->getMessage()));
-            NMM_Util::log(__FILE__, __LINE__, 'Something went wrong during checkout: ' . $e->getMessage());
-            echo '<div class="woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout">';
-            echo '<ul class="woocommerce-error">';
-            echo '<li>';
-            echo esc_html__('Something went wrong.', 'nomiddleman-crypto-payments-for-woocommerce') . '<br>';
-            echo esc_html($e->getMessage());
-            echo '</li>';
-            echo '</ul>';
-            echo '</div>';
+            // Errors from the fast path (re-displaying an already-initialized
+            // order). Do not fail the order for a display hiccup - it may already
+            // be paid; just surface the message. Initialization failures are
+            // handled and failed under the lock above.
+            NMM_Util::log(__FILE__, __LINE__, 'Error rendering the payment page: ' . $e->getMessage());
+            $this->render_checkout_error($e->getMessage());
         }
+    }
+
+    private function render_checkout_error($message) {
+        echo '<div class="woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout">';
+        echo '<ul class="woocommerce-error">';
+        echo '<li>';
+        echo esc_html__('Something went wrong.', 'nomiddleman-crypto-payments-for-woocommerce') . '<br>';
+        echo esc_html($message);
+        echo '</li>';
+        echo '</ul>';
+        echo '</div>';
+    }
+
+    // Re-display an order whose payment address was already allocated (page
+    // refresh, or a concurrent first load that lost the init lock). Shows a
+    // terminal message for paid/cancelled/failed orders, otherwise the live
+    // payment status. Never allocates - allocation happens once, under the lock.
+    private function display_existing_payment($order, $order_id) {
+        if ($order->is_paid()) {
+            echo '<p class="nmm-status-paid">' . esc_html__('Payment received - thank you! Your order is being processed.', 'nomiddleman-crypto-payments-for-woocommerce') . '</p>';
+            return;
+        }
+
+        // Do not re-display payment instructions for an order that is no longer
+        // awaiting payment. Its address may have been recycled to a different
+        // order, so a late payment would credit someone else.
+        if ($order->has_status(array('cancelled', 'failed'))) {
+            echo '<p class="nmm-status-cancelled">' . esc_html__('This order is no longer awaiting payment. Please do not send any funds to the address shown previously. If you believe this is an error, contact the store.', 'nomiddleman-crypto-payments-for-woocommerce') . '</p>';
+            return;
+        }
+
+        $this->handle_thank_you_refresh(
+            $order->get_meta('crypto_type_id'),
+            $order->get_meta('wallet_address'),
+            $order->get_meta('crypto_amount'),
+            $order_id);
     }
 
     public function additional_email_details($order, $sent_to_admin, $plain_text, $email) {

--- a/src/NMM_Payment_Repo.php
+++ b/src/NMM_Payment_Repo.php
@@ -73,6 +73,23 @@ class NMM_Payment_Repo {
 		return $results;
 	}
 
+	/**
+	 * Remove unpaid payment rows left behind by an initialization attempt that
+	 * inserted a row and then failed before persisting the order's wallet_address.
+	 * A fresh attempt must clear them, or UNIQUE(order_id, order_amount) would
+	 * silently reject its insert and the customer would be shown an address that
+	 * nobody is monitoring. Only 'unpaid' rows are removed - a paid or cancelled
+	 * row is a real record and is never touched.
+	 */
+	public function delete_unpaid_for_order($orderId) {
+		global $wpdb;
+
+		return $wpdb->query($wpdb->prepare(
+			"DELETE FROM `$this->tableName` WHERE `order_id` = %d AND `status` = 'unpaid'",
+			$orderId
+		));
+	}
+
 	public function get_unpaid_for_address($cryptoId, $address) {
 		global $wpdb;
 

--- a/src/NMM_Util.php
+++ b/src/NMM_Util.php
@@ -74,6 +74,40 @@ class NMM_Util {
 		return extension_loaded('gmp') || extension_loaded('bcmath');
 	}
 
+	// Per-order advisory lock name. Scoped to this site AND this order so distinct
+	// orders never share a lock, and neither do same-numbered orders on different
+	// sites. The table prefix ($wpdb->prefix) is blog-specific on multisite, where
+	// sites share DB_NAME and WooCommerce order ids can overlap; DB_NAME still
+	// separates sites that merely share a MySQL server. Both are hashed to a fixed
+	// length so they can never push the (variable-length) order id past MySQL's
+	// 64-char lock-name limit - which would truncate and collide DIFFERENT orders.
+	private static function order_init_lock_name($orderId) {
+		global $wpdb;
+
+		return 'nmm_oinit_' . (int) $orderId . '_' . substr(md5(DB_NAME . '|' . $wpdb->prefix), 0, 12);
+	}
+
+	/**
+	 * Acquire the per-order initialization lock so two concurrent first loads of
+	 * the thank-you page cannot both allocate a payment address for one order.
+	 * GET_LOCK is atomic across connections, owned by the acquiring connection,
+	 * and released automatically if that PHP process dies, so a crash can never
+	 * wedge it. Returns the raw GET_LOCK result: '1' acquired, '0' timed out,
+	 * null if advisory locks are unavailable on this host. The caller must call
+	 * release_order_init_lock() only when this returned '1'.
+	 */
+	public static function acquire_order_init_lock($orderId, $timeoutSeconds = 15) {
+		global $wpdb;
+
+		return $wpdb->get_var($wpdb->prepare('SELECT GET_LOCK(%s, %d)', self::order_init_lock_name($orderId), $timeoutSeconds));
+	}
+
+	public static function release_order_init_lock($orderId) {
+		global $wpdb;
+
+		$wpdb->query($wpdb->prepare('SELECT RELEASE_LOCK(%s)', self::order_init_lock_name($orderId)));
+	}
+
 }
 
 ?>

--- a/tests/test-order-init-lock.php
+++ b/tests/test-order-init-lock.php
@@ -99,6 +99,24 @@ if (defined('NMM_PAYMENT_TABLE')) {
 	lok('exactly one payment row for the order',    $count === 1, 'count=' . $count);
 	lok('the first worker\'s address is the one kept', $addr === 'addr_worker_A', 'addr=' . $addr);
 	$wpdb->query($wpdb->prepare("DELETE FROM `$pt` WHERE order_id=%d", $orderA));
+
+	// A failed attempt can leave an unpaid row behind (inserted, then threw before
+	// wallet_address was persisted). A retry must clear it, or its own insert would
+	// be silently rejected by UNIQUE(order_id, order_amount) and it would display an
+	// address nobody monitors. Paid rows must survive.
+	$repo->insert('addr_stale_attempt', 'BTC', $orderA, '0.00100000', 'unpaid');
+	$repo->delete_unpaid_for_order($orderA);
+	lok('stale unpaid row from a failed attempt cleared', (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM `$pt` WHERE order_id=%d", $orderA)) === 0);
+	$repo->insert('addr_retry', 'BTC', $orderA, '0.00100000', 'unpaid'); // retry now inserts cleanly
+	$retryAddr = $wpdb->get_var($wpdb->prepare("SELECT address FROM `$pt` WHERE order_id=%d", $orderA));
+	lok('retry row is the monitored one',           $retryAddr === 'addr_retry', 'addr=' . $retryAddr);
+
+	// A settled (paid) row is a real record and must never be cleared.
+	$wpdb->query($wpdb->prepare("DELETE FROM `$pt` WHERE order_id=%d", $orderA));
+	$repo->insert('addr_paid', 'BTC', $orderA, '0.00200000', 'paid');
+	$repo->delete_unpaid_for_order($orderA);
+	lok('paid row is never cleared',                (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM `$pt` WHERE order_id=%d AND status='paid'", $orderA)) === 1);
+	$wpdb->query($wpdb->prepare("DELETE FROM `$pt` WHERE order_id=%d", $orderA));
 }
 
 $wpdb2->close();

--- a/tests/test-order-init-lock.php
+++ b/tests/test-order-init-lock.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Live-DB test: the per-order initialization lock (NMM_Util::acquire/release_
+ * order_init_lock) serializes two concurrent first loads of the thank-you page
+ * so they cannot both allocate a payment address for the same order, and is
+ * scoped per order so distinct orders never block each other. Also checks that
+ * the payment table's UNIQUE(order_id, order_amount) constraint keeps exactly
+ * one payment record per order even if a second worker slipped through.
+ * Requires WordPress + a database. Skips cleanly standalone.
+ *
+ *   Run:  wp eval-file tests/test-order-init-lock.php
+ */
+
+if (!isset($GLOBALS['wpdb']) || !is_object($GLOBALS['wpdb'])) {
+	echo "test-order-init-lock: skipped (needs WordPress + DB)\n";
+	return;
+}
+
+$wpdb = $GLOBALS['wpdb'];
+$pt = $wpdb->prefix . NMM_PAYMENT_TABLE;
+
+$GLOBALS['ol_ok'] = true;
+function lok($label, $cond, $extra = '') { printf("%-56s %s%s\n", $label, $cond ? 'ok' : 'FAIL', $extra !== '' ? "  $extra" : ''); if (!$cond) { $GLOBALS['ol_ok'] = false; } }
+
+$orderA = 8100001;
+$orderB = 8100002;
+
+// A second, independent DB connection to stand in for a concurrent request:
+// GET_LOCK is owned per-connection, so a lock held on $wpdb2 blocks the main
+// connection exactly as two PHP workers would contend.
+$wpdb2 = new wpdb(DB_USER, DB_PASSWORD, DB_NAME, DB_HOST);
+$wpdb2->suppress_errors(true);
+$main = $GLOBALS['wpdb'];
+// Two concurrent requests on the SAME site share the table prefix; a fresh wpdb
+// does not initialize it, so mirror the main connection's so the per-site lock
+// name matches (the lock is scoped by DB_NAME + prefix).
+$wpdb2->prefix = $main->prefix;
+
+// Worker A (connection 2) acquires the init lock for order A.
+$GLOBALS['wpdb'] = $wpdb2;
+$aHeld = NMM_Util::acquire_order_init_lock($orderA, 0);
+$GLOBALS['wpdb'] = $main;
+lok('worker A acquires order-init lock',        $aHeld === '1', 'got=' . var_export($aHeld, true));
+
+// Worker B (main connection) must NOT get the same order's lock (0s timeout).
+$bSameOrder = NMM_Util::acquire_order_init_lock($orderA, 0);
+lok('worker B blocked on the SAME order',       $bSameOrder === '0', 'got=' . var_export($bSameOrder, true));
+
+// A different order is independently lockable - scoping works, no false sharing.
+$bOtherOrder = NMM_Util::acquire_order_init_lock($orderB, 0);
+lok('a DIFFERENT order is not blocked',         $bOtherOrder === '1', 'got=' . var_export($bOtherOrder, true));
+if ($bOtherOrder === '1') { NMM_Util::release_order_init_lock($orderB); }
+
+// A releases; the same order becomes lockable again.
+$GLOBALS['wpdb'] = $wpdb2;
+NMM_Util::release_order_init_lock($orderA);
+$GLOBALS['wpdb'] = $main;
+$bAfterRelease = NMM_Util::acquire_order_init_lock($orderA, 0);
+lok('same order lockable after A releases',     $bAfterRelease === '1', 'got=' . var_export($bAfterRelease, true));
+if ($bAfterRelease === '1') { NMM_Util::release_order_init_lock($orderA); }
+
+// Multisite scoping: the SAME order id on a DIFFERENT site (different table
+// prefix) must NOT contend - those are unrelated orders that merely share
+// DB_NAME and an id. The main site holds order A; a second site's request for
+// "order A" should acquire freely.
+$mainHold = NMM_Util::acquire_order_init_lock($orderA, 0);
+$wpdb2->prefix = $main->prefix . 's2_'; // pretend a second network site
+$GLOBALS['wpdb'] = $wpdb2;
+$site2 = NMM_Util::acquire_order_init_lock($orderA, 0);
+if ($site2 === '1') { NMM_Util::release_order_init_lock($orderA); }
+$GLOBALS['wpdb'] = $main;
+$wpdb2->prefix = $main->prefix; // restore for the remaining checks
+lok('same order id on a DIFFERENT site is free', $mainHold === '1' && $site2 === '1', "$mainHold,$site2");
+if ($mainHold === '1') { NMM_Util::release_order_init_lock($orderA); }
+
+// The lock name must be order-specific even if DB_NAME is long: two different
+// orders must never collide on one truncated 64-char lock name. Prove it by
+// holding both at once on connection 2.
+$GLOBALS['wpdb'] = $wpdb2;
+$h1 = NMM_Util::acquire_order_init_lock($orderA, 0);
+$h2 = NMM_Util::acquire_order_init_lock($orderB, 0);
+lok('two distinct orders hold locks at once',   $h1 === '1' && $h2 === '1', "$h1,$h2");
+NMM_Util::release_order_init_lock($orderA);
+NMM_Util::release_order_init_lock($orderB);
+$GLOBALS['wpdb'] = $main;
+
+// Even if two workers both reached the insert, UNIQUE(order_id, order_amount)
+// permits only one payment record for the order - so there can never be two
+// competing monitored rows for one order+amount.
+if (defined('NMM_PAYMENT_TABLE')) {
+	$wpdb->query($wpdb->prepare("DELETE FROM `$pt` WHERE order_id=%d", $orderA));
+	$repo = new NMM_Payment_Repo();
+	$repo->insert('addr_worker_A', 'BTC', $orderA, '0.00100000', 'unpaid');
+	$wpdb->suppress_errors(true);
+	$repo->insert('addr_worker_B', 'BTC', $orderA, '0.00100000', 'unpaid'); // duplicate order+amount
+	$wpdb->suppress_errors(false);
+	$count = (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM `$pt` WHERE order_id=%d AND order_amount='0.00100000'", $orderA));
+	$addr = $wpdb->get_var($wpdb->prepare("SELECT address FROM `$pt` WHERE order_id=%d", $orderA));
+	lok('exactly one payment row for the order',    $count === 1, 'count=' . $count);
+	lok('the first worker\'s address is the one kept', $addr === 'addr_worker_A', 'addr=' . $addr);
+	$wpdb->query($wpdb->prepare("DELETE FROM `$pt` WHERE order_id=%d", $orderA));
+}
+
+$wpdb2->close();
+
+// Post-lock recheck must see a wallet_address committed by another worker after
+// this request first read the order (which caches an empty value). The gateway
+// forces a fresh meta read under the lock; assert that a forced re-read reflects
+// a value written behind a previously-read order object's back.
+if (function_exists('wc_create_order')) {
+	$o = wc_create_order();
+	$o->save();
+	$oid = $o->get_id();
+
+	$staleOrder = wc_get_order($oid);
+	$staleOrder->get_meta('wallet_address'); // populate this object's meta cache (empty)
+
+	// Simulate the lock holder committing the address via a separate load.
+	$holder = wc_get_order($oid);
+	$holder->update_meta_data('wallet_address', 'ADDR_FROM_HOLDER');
+	$holder->save();
+
+	$staleOrder->read_meta_data(true); // exactly what the gateway does post-lock
+	lok('forced re-read sees the committed address', $staleOrder->get_meta('wallet_address') === 'ADDR_FROM_HOLDER', 'got=' . $staleOrder->get_meta('wallet_address'));
+
+	$holder->delete(true);
+}
+
+echo $GLOBALS['ol_ok'] ? "\nORDER-INIT-LOCK CHECKS PASSED\n" : "\nORDER-INIT-LOCK CHECKS FAILED\n";


### PR DESCRIPTION
Fixes the P1 from the post-2.9.4 review: **thank-you payment initialization is not concurrency-safe**.

Initialization was check-then-act, so two near-simultaneous first loads of the same order could both pass the empty-`wallet_address` check and each allocate a different address (Monero subaddress / carousel). The unique payment constraint admits one payment row, but the later request could overwrite `wallet_address` with an address that is **not** the one being monitored — a payment to the displayed address would never be matched.

Initialization now runs under a per-order MySQL advisory lock:

- `NMM_Util::acquire/release_order_init_lock()` — named from the order id + a hash of `DB_NAME` and the table prefix (distinct orders never share a lock; same-numbered orders on different multisite sites don't contend; a long DB name can't truncate the id).
- Re-fetch + **forced** meta read (`read_meta_data(true)`) under the lock, so a stale request-local cache can't cause a second allocation; if the other worker finished, its address is displayed.
- Lock held (`'0'`) → **do not allocate**; show a brief "preparing your payment details, please refresh" notice. Only genuinely unavailable locks (`null`) degrade to unprotected init (pre-lock behaviour).
- A failed init is marked `wc-failed` **inside** the lock (catch before finally), so it can't overwrite a concurrent success. An `$initializing` flag means a display error on an already-initialized (possibly paid) order never fails it.
- Page refresh takes a fast path with no lock.

**Test:** `tests/test-order-init-lock.php` (new, wired into the CI database job, fails if it skips) — cross-connection mutual exclusion, per-order and per-site scoping, release, forced-meta-read visibility, and one payment row per order.

The bounded-Autopay-scan work (the P2 from the same review) is deliberately **not** in this release; it is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)