### PR TITLE
2.9.7: address-level coverage, bulk-response accounting, Throwable boundary

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Requires at least: 5.0
 Tested up to: 7.0
 Requires PHP: 7.4
 License: GPL v3
-Stable Tag: 2.9.6
+Stable Tag: 2.9.7
 
 Absolutely the easiest setup in the industry. No registration. No API keys. No middleman. Accept bitcoin, ethereum, litecoin, and more.
 
@@ -182,6 +182,11 @@ Yes. Filters are available for redirecting verification requests, customizing th
 Yes - as a safeguard. Privacy Mode derives a fresh address per order from your master public key. To avoid handing out an ever-growing range of addresses, the plugin returns an address to the pool for reuse **only** if the order was abandoned without paying and fresh block-explorer checks confirm the address never received anything on-chain; any address that saw funds is retired permanently. This keeps a run of abandoned checkouts from advancing the derivation index unnecessarily. As defense-in-depth, set your receiving wallet's **gap limit** (the number of consecutive unused addresses it scans from the seed - 20 by default in Electrum) comfortably above the longest run of abandoned checkouts you would expect between payments, so a paid address is always discovered on seed recovery. In Electrum this is `wallet.change_gap_limit` / the `gap_limit_for_change` and address gap-limit settings; other HD wallets have an equivalent. This wallet setting should be a backstop, not the plugin's primary protection.
 
 == Changelog ==
+
+= 2.9.7 =
+* Autopay: verification completeness is now tracked per address instead of per currency - a single very busy (or deliberately dust-flooded) payment address can no longer pause automatic order expiry for every order of that cryptocurrency; only orders on the affected address wait until it can be conclusively checked
+* Autopay: bulk transaction lookups (Cardano, Bitcoin SV) now verify that the explorer returned details for every requested transaction - a partial reply is retried instead of being mistaken for a completed check
+* Hardening: a malformed explorer reply can no longer abort the background verification run part-way through - it is treated as an ordinary failed lookup and retried
 
 = 2.9.6 =
 * Performance: the Autopay verifier now checks a bounded number of unpaid addresses per cron tick and advances a persisted fair cursor so every address is still eventually checked - a large backlog of abandoned orders can no longer hold the background job's lock and delay payment, expiry, HD and Solana work. Monero verification fetches an account's incoming transfers once per tick and groups them by subaddress locally, instead of two wallet-RPC calls per address

--- a/nomiddleman-crypto-woocommerce.php
+++ b/nomiddleman-crypto-woocommerce.php
@@ -7,7 +7,7 @@ Plugin URI:  https://wordpress.org/plugins/nomiddleman-crypto-payments-for-wooco
 Description: WooCommerce Bitcoin and Cryptocurrency Payment Gateway
 Author: nomiddleman
 Author URI: https://github.com/rmwb/nomiddleman-woocommerce
-Version: 2.9.6
+Version: 2.9.7
 Requires PHP: 7.4
 Text Domain: nomiddleman-crypto-payments-for-woocommerce
 Domain Path: /languages
@@ -71,7 +71,7 @@ function NMM_init_gateways(){
     define('NMM_PLUGIN_FILE', __FILE__);
     define('NMM_ABS_PATH', dirname(NMM_PLUGIN_FILE));
 
-    define('NMM_VERSION', '2.9.6');
+    define('NMM_VERSION', '2.9.7');
     
     define('NMM_REDUX_SLUG', 'nmmpro_options');
 
@@ -336,6 +336,8 @@ function NMM_delete_scan_options() {
         'nmm_autopay_scan_covered_at',
         'nmm_autopay_scan_sweep_start',
         'nmm_autopay_scan_dirty',
+        'nmm_autopay_scan_incomplete',
+        'nmm_autopay_scan_incomplete_next',
     );
 
     if (is_multisite()) {

--- a/src/NMM_Blockchain.php
+++ b/src/NMM_Blockchain.php
@@ -534,11 +534,23 @@ class NMM_Blockchain {
 			}
 
 			$utxoRows = json_decode($response2['body']);
+			if (!is_array($utxoRows)) {
+				NMM_Util::log(__FILE__, __LINE__, 'koios tx_utxos: malformed bulk response body; failing the visit for retry.');
 
-			foreach ((array) $utxoRows as $utxoRow) {
-				if (!isset($utxoRow->outputs) || !is_array($utxoRow->outputs)) {
+				return array(
+					'result' => 'error',
+					'total_received' => '',
+				);
+			}
+
+			$seenHashes = array();
+			foreach ($utxoRows as $utxoRow) {
+				if (!isset($utxoRow->tx_hash) || !isset($utxoRow->outputs) || !is_array($utxoRow->outputs)) {
+					// Malformed row: leave its hash unaccounted so the check
+					// below fails the whole visit.
 					continue;
 				}
+				$seenHashes[$utxoRow->tx_hash] = true;
 
 				// amounts are in lovelace (1e-6 ADA), matching ADA's round precision
 				$received = 0;
@@ -553,6 +565,23 @@ class NMM_Blockchain {
 														  10000,
 														  isset($txTimes[$utxoRow->tx_hash]) ? $txTimes[$utxoRow->tx_hash] : time(),
 														  $utxoRow->tx_hash);
+				}
+			}
+
+			// Account for every requested hash: Koios can return HTTP 200 with
+			// an empty or partial result set, and a transaction missing from
+			// (or malformed in) the bulk response was NOT inspected - treating
+			// it as "no payment" would let a short address page certify
+			// coverage over an unverified payment. Fail the visit so the
+			// verifier retries it instead.
+			foreach ($txHashes as $requestedHash) {
+				if (!isset($seenHashes[$requestedHash])) {
+					NMM_Util::log(__FILE__, __LINE__, 'koios tx_utxos: transaction ' . $requestedHash . ' missing from the bulk response; failing the visit for retry.');
+
+					return array(
+						'result' => 'error',
+						'total_received' => '',
+					);
 				}
 			}
 		}
@@ -678,8 +707,11 @@ class NMM_Blockchain {
 
 		$body = json_decode($response['body']);
 
-		if (property_exists($body, 'error')) {
-			NMM_Util::log(__FILE__, __LINE__, 'FAILED API CALL ( ' . $request . ' ): ' . $body->error);
+		// A malformed 200 body decodes to null/scalar; property_exists() on a
+		// non-object throws a TypeError on PHP 8, which would escape the
+		// verifier's fetch boundary - treat it as the fetch failure it is.
+		if (!is_object($body) || property_exists($body, 'error')) {
+			NMM_Util::log(__FILE__, __LINE__, 'FAILED API CALL ( ' . $request . ' ): ' . (is_object($body) ? $body->error : 'malformed response body'));
 			$result = array(
 				'result' => 'error',
 				'total_received' => '',
@@ -865,10 +897,24 @@ class NMM_Blockchain {
 				);
 			}
 
-			foreach ((array) json_decode($response2['body']) as $rawTransaction) {
-				if (!isset($rawTransaction->vout) || !is_array($rawTransaction->vout)) {
+			$rawTransactions = json_decode($response2['body']);
+			if (!is_array($rawTransactions)) {
+				NMM_Util::log(__FILE__, __LINE__, 'whatsonchain bulk txs: malformed bulk response body; failing the visit for retry.');
+
+				return array(
+					'result' => 'error',
+					'total_received' => '',
+				);
+			}
+
+			$seenHashes = array();
+			foreach ($rawTransactions as $rawTransaction) {
+				if (!isset($rawTransaction->txid) || !isset($rawTransaction->vout) || !is_array($rawTransaction->vout)) {
+					// Malformed row: leave its hash unaccounted so the check
+					// below fails the whole visit.
 					continue;
 				}
+				$seenHashes[$rawTransaction->txid] = true;
 
 				$height = isset($txHeights[$rawTransaction->txid]) ? $txHeights[$rawTransaction->txid] : 0;
 				$confirmations = ($height > 0 && $tipHeight > 0) ? $tipHeight - $height + 1 : 0;
@@ -880,6 +926,23 @@ class NMM_Blockchain {
 															  isset($rawTransaction->time) ? $rawTransaction->time : time(),
 															  $rawTransaction->txid);
 					}
+				}
+			}
+
+			// Account for every requested hash: WhatsOnChain can return HTTP
+			// 200 with an empty or partial result set (null entries for
+			// unknown txids), and a transaction missing from the bulk response
+			// was NOT inspected - treating it as "no payment" would let a
+			// short address page certify coverage over an unverified payment.
+			// Fail the visit so the verifier retries it instead.
+			foreach ($txHashes as $requestedHash) {
+				if (!isset($seenHashes[$requestedHash])) {
+					NMM_Util::log(__FILE__, __LINE__, 'whatsonchain bulk txs: transaction ' . $requestedHash . ' missing from the bulk response; failing the visit for retry.');
+
+					return array(
+						'result' => 'error',
+						'total_received' => '',
+					);
 				}
 			}
 		}
@@ -1834,8 +1897,11 @@ class NMM_Blockchain {
 
 		$body = json_decode($response['body']);
 
-		if (property_exists($body, 'error')) {
-			NMM_Util::log(__FILE__, __LINE__, 'FAILED API CALL ( ' . $request . ' ): ' . $body->error);
+		// A malformed 200 body decodes to null/scalar; property_exists() on a
+		// non-object throws a TypeError on PHP 8, which would escape the
+		// verifier's fetch boundary - treat it as the fetch failure it is.
+		if (!is_object($body) || property_exists($body, 'error')) {
+			NMM_Util::log(__FILE__, __LINE__, 'FAILED API CALL ( ' . $request . ' ): ' . (is_object($body) ? $body->error : 'malformed response body'));
 			$result = array(
 				'result' => 'error',
 				'total_received' => '',

--- a/src/NMM_Payment.php
+++ b/src/NMM_Payment.php
@@ -199,7 +199,8 @@ class NMM_Payment {
 		$xmrByAddress = array();
 
 		$newFailed = array();
-		$partialCryptos = array();
+		$coinDirty = array();       // whole-coin exclusions (unverifiable ticker)
+		$incompleteKeys = array();  // per-ADDRESS exclusions ("crypto|address")
 
 		foreach ($toProcess as $record) {
 			$cryptoId = $record['cryptocurrency'];
@@ -209,10 +210,10 @@ class NMM_Payment {
 				// A ticker no longer in the registry (coin support removed)
 				// cannot be verified at all - it must not be certified covered,
 				// or expiry would cancel its orders without any payment check.
-				// Dirty (not failed): there is no point re-fetching it every
-				// tick, and the next sweep re-marks it for as long as its
-				// unpaid rows exist, so they are never auto-cancelled.
-				$partialCryptos[$cryptoId] = true;
+				// Coin-level dirty (not failed): there is no point re-fetching
+				// it every tick, and the next sweep re-marks it for as long as
+				// its unpaid rows exist, so they are never auto-cancelled.
+				$coinDirty[$cryptoId] = true;
 				continue;
 			}
 			$crypto = $cryptos[$cryptoId];
@@ -246,18 +247,24 @@ class NMM_Payment {
 					// not yet inspected this address's whole matching window
 					// (a busy or dusted address spans several ticks). Not a
 					// failure - collected payments were returned and progress
-					// is durable - but not verification either: the coin must
-					// not be certified covered while signatures below the
+					// is durable - but not verification either: THIS ADDRESS
+					// must not be certified while signatures below its
 					// internal cursor, or in its retry queue, are uninspected.
-					$partialCryptos[$cryptoId] = true;
+					// Address-level, not coin-level: one busy address must not
+					// freeze expiry for the whole currency.
+					$incompleteKeys[self::scan_key($record)] = true;
 				}
 				elseif ($cryptoId !== 'SOL' && self::page_possibly_truncated($cryptoId, $fetched, $cryptoLifetime, $now)) {
 					// A full newest-page (raw, pre-filtering) whose oldest
 					// entry is still inside the matching window: in-window
 					// history may be hidden below the fixed-depth page (see
 					// page_possibly_truncated) - a valid check, but not
-					// certifiable coverage.
-					$partialCryptos[$cryptoId] = true;
+					// certifiable coverage for THIS ADDRESS. Address-level,
+					// not coin-level: a permanently busy (or deliberately
+					// dusted) address would otherwise mark the coin dirty on
+					// every sweep and no order of that currency would ever
+					// auto-cancel.
+					$incompleteKeys[self::scan_key($record)] = true;
 				}
 			}
 		}
@@ -272,23 +279,47 @@ class NMM_Payment {
 		// again). Without this, an endpoint recovering after drops would let a
 		// later clean wrap certify coverage for addresses that were never
 		// successfully checked, and an aged paid order could be cancelled.
-		$dirtyAdd = $partialCryptos;
 		$retryCap = max(1, (int) apply_filters('nmm_autopay_scan_retry_cap', 200));
 		$newFailed = array_values(array_unique($newFailed));
 		if (count($newFailed) > $retryCap) {
+			// Dropped keys will not be retried, so their addresses stay
+			// unverified until the next sweep visits them - exclude exactly
+			// those addresses (not their whole coins) from certification.
 			foreach (array_slice($newFailed, $retryCap) as $droppedKey) {
-				$droppedParts = explode('|', $droppedKey, 2);
-				$dirtyAdd[$droppedParts[0]] = true;
+				$incompleteKeys[$droppedKey] = true;
 			}
 			$newFailed = array_slice($newFailed, 0, $retryCap);
 		}
-		if (!empty($dirtyAdd)) {
+
+		// Accumulate this tick's per-address incompleteness (truncated pages,
+		// mid-window Solana sweeps, dropped retries) into the BUILDER set for
+		// the sweep in progress; the wrap below promotes it to the active
+		// exclusion set that cancel_expired_payments() consults. Bounded: past
+		// the cap we can no longer track addresses individually, so the
+		// overflow's coins fall back to the coarse coin-level dirty marker.
+		if (!empty($incompleteKeys)) {
+			$builder = get_option('nmm_autopay_scan_incomplete_next', array());
+			if (!is_array($builder)) {
+				$builder = array();
+			}
+			foreach (array_keys($incompleteKeys) as $incompleteKey) {
+				if (count($builder) >= 500 && !isset($builder[$incompleteKey])) {
+					$incompleteParts = explode('|', $incompleteKey, 2);
+					$coinDirty[$incompleteParts[0]] = true;
+					continue;
+				}
+				$builder[$incompleteKey] = true;
+			}
+			update_option('nmm_autopay_scan_incomplete_next', $builder, false);
+		}
+
+		if (!empty($coinDirty)) {
 			$dirty = get_option('nmm_autopay_scan_dirty', array());
 			if (!is_array($dirty)) {
 				$dirty = array();
 			}
-			foreach (array_keys($dirtyAdd) as $dirtyAddCryptoId) {
-				$dirty[$dirtyAddCryptoId] = true;
+			foreach (array_keys($coinDirty) as $dirtyCryptoId) {
+				$dirty[$dirtyCryptoId] = true;
 			}
 			update_option('nmm_autopay_scan_dirty', $dirty, false);
 		}
@@ -316,41 +347,31 @@ class NMM_Payment {
 		// protected until a genuinely complete sweep finishes. A single page
 		// covering the whole backlog stamps this tick's own start.
 		//
-		// Coverage is stamped PER CURRENCY, and a currency with an unresolved
-		// fetch failure ($newFailed carries this tick's failures AND re-failed
-		// retries from earlier ticks) keeps its previous stamp: a failed
-		// address was not verified, and stamping it would let cancellation
-		// treat it as checked. Scoping this per currency matters - one
-		// permanently failing endpoint (say, an unconfigured Monero wallet
-		// RPC) must only hold back ITS coin's expirations, not freeze
-		// cancellation for every currency on the store. The retry path
-		// re-checks the failed address next tick, and that coin's stamp waits
-		// for the next wrap with all of its fetches clean.
-		//
-		// The stamp's claim is "every address of this coin was checked, with
-		// nothing relevant possibly hidden, after the row's window closed".
-		// Three incompleteness signals guard it: fetch failures (above),
-		// Solana's own multi-tick sweep state (sol_address_fully_swept), and
-		// the generic full-page truncation check (page_possibly_truncated) for
-		// the fixed-depth explorer adapters - all three route into the dirty
-		// marker below.
+		// Coverage is stamped PER CURRENCY, with incompleteness tracked PER
+		// ADDRESS. The stamp's claim is "every address of this coin was
+		// checked, with nothing relevant possibly hidden, after the row's
+		// window closed - EXCEPT the addresses in the active exclusion set,
+		// whose rows defer". The exclusion set (promoted from the builder at
+		// each wrap, plus the keys still failing in the retry set) carries the
+		// addresses the sweep could not conclusively verify: fetch failures,
+		// Solana mid-window sweeps, possibly-truncated fixed-depth pages, and
+		// dropped retries. Address-level granularity matters in both
+		// directions: one permanently failing endpoint or one busy/dusted
+		// address must only hold back ITS OWN rows' expirations, never freeze
+		// cancellation for a whole currency - and conversely an excluded
+		// address's rows never expire until a sweep verifies it cleanly (the
+		// next wrap then simply drops it from the set). Only a ticker missing
+		// from the registry (nothing of that coin can ever be verified) still
+		// blocks its coin's stamp via the coin-level dirty marker.
 		if ($wrapped || $take >= $total) {
-			$failedCryptos = array();
-			foreach ($newFailed as $failedKey) {
-				$failedParts = explode('|', $failedKey, 2);
-				$failedCryptos[$failedParts[0]] = true;
-			}
-
-			// Currencies marked dirty during this sweep - failed keys dropped
-			// from the retry set, or a Solana address whose bounded internal
-			// history sweep is still mid-window - have addresses that were not
-			// fully verified: exclude them from this stamp, then clear the
-			// marker. The sweep now starting revisits every address, and a
-			// still-incomplete address simply re-marks its coin dirty.
+			// Coin-level exclusions: unverifiable tickers and address-tracking
+			// overflow. Cleared after use - the sweep now starting re-marks
+			// them for as long as their rows exist.
+			$excludedCryptos = array();
 			$dirty = get_option('nmm_autopay_scan_dirty', array());
 			if (is_array($dirty) && !empty($dirty)) {
 				foreach (array_keys($dirty) as $dirtyCryptoId) {
-					$failedCryptos[$dirtyCryptoId] = true;
+					$excludedCryptos[$dirtyCryptoId] = true;
 				}
 				update_option('nmm_autopay_scan_dirty', array(), false);
 			}
@@ -361,11 +382,26 @@ class NMM_Payment {
 				$coveredMap = array();
 			}
 			foreach ($paymentRepo->get_distinct_unpaid_cryptos() as $sweptCryptoId) {
-				if (!isset($failedCryptos[$sweptCryptoId])) {
+				if (!isset($excludedCryptos[$sweptCryptoId])) {
 					$coveredMap[$sweptCryptoId] = $stampAt;
 				}
 			}
 			update_option('nmm_autopay_scan_covered_at', $coveredMap, false);
+
+			// Promote the completed sweep's incomplete addresses to the ACTIVE
+			// exclusion set cancel_expired_payments() consults, adding the
+			// keys still failing in the retry set (they were visited but never
+			// verified). The builder resets: the sweep now starting revisits
+			// every address, and a still-incomplete one re-enters the builder.
+			$promoted = get_option('nmm_autopay_scan_incomplete_next', array());
+			if (!is_array($promoted)) {
+				$promoted = array();
+			}
+			foreach ($newFailed as $failedKey) {
+				$promoted[$failedKey] = true;
+			}
+			update_option('nmm_autopay_scan_incomplete', $promoted, false);
+			update_option('nmm_autopay_scan_incomplete_next', array(), false);
 
 			// The next sweep begins with the head rows this tick just fetched.
 			update_option('nmm_autopay_scan_sweep_start', $now, false);
@@ -456,8 +492,13 @@ class NMM_Payment {
 		try {
 			$transactions = self::get_address_transactions($cryptoId, $address, $transactionLifetime);
 		}
-		catch (\Exception $e) {
-			NMM_Util::log(__FILE__, __LINE__, 'Unable to get transactions for ' . $cryptoId);
+		catch (\Throwable $e) {
+			// \Throwable, not \Exception: adapter parsing of a malformed
+			// HTTP-200 body can raise TypeError/Error on PHP 8, and an
+			// uncaught one would abort the whole sweep BEFORE the cursor and
+			// retry state persist - the same bad address would then terminate
+			// every cron run. A throw here is just a failed fetch: retry it.
+			NMM_Util::log(__FILE__, __LINE__, 'Unable to get transactions for ' . $cryptoId . ': ' . $e->getMessage(), 'warning');
 			return false;
 		}
 
@@ -883,6 +924,15 @@ class NMM_Payment {
 			$coveredMap = array(); // unknown format: treat as no coverage (defer, never cancel unverified)
 		}
 
+		// Addresses the last completed sweep could not conclusively verify
+		// (failing endpoint, possibly-truncated page, mid-window Solana sweep,
+		// dropped retry). Their rows defer - only theirs; the coin's other
+		// orders expire normally against the coin's stamp.
+		$incompleteAddrs = get_option('nmm_autopay_scan_incomplete', array());
+		if (!is_array($incompleteAddrs)) {
+			$incompleteAddrs = array();
+		}
+
 		// Only rows old enough to be expirable for SOME configured coin can
 		// possibly be cancelled. The shortest cancellation window among the coins
 		// that actually have unpaid rows is a safe coarse cutoff: anything newer
@@ -927,6 +977,16 @@ class NMM_Payment {
 			NMM_Util::log(__FILE__, __LINE__, 'cryptoID: ' . $cryptoId . ' payment cancellation time sec: ' . $paymentCancellationTimeSec . ' time since order: ' . $timeSinceOrder);
 
 			if ($timeSinceOrder > $paymentCancellationTimeSec) {
+				if (isset($incompleteAddrs[$cryptoId . '|' . $paymentRecord['address']])) {
+					// This address was not conclusively verified by the last
+					// completed sweep - a payment may be hidden from view, so
+					// its rows must not expire yet. The exclusion refreshes at
+					// every wrap: once a sweep verifies the address cleanly,
+					// expiry resumes on the next cancellation pass.
+					NMM_Util::log(__FILE__, __LINE__, 'Autopay: deferring expiry for ' . $cryptoId . ' address ' . $paymentRecord['address'] . ' (not conclusively verified by the last sweep).');
+					continue;
+				}
+
 				$orderId = $paymentRecord['order_id'];
 				$orderAmount = $paymentRecord['order_amount'];
 				$address = $paymentRecord['address'];

--- a/tests/test-autopay-cancel.php
+++ b/tests/test-autopay-cancel.php
@@ -317,7 +317,8 @@ add_filter('nmm_xmr_account_transactions', function () { return array('result' =
 NMM_Payment::check_all_addresses_for_matching_payment(3 * 3600);
 remove_all_filters('nmm_xmr_account_transactions');
 $covMap = get_option('nmm_autopay_scan_covered_at', array());
-aok('failed fetch does not stamp coverage',      !is_array($covMap) || !isset($covMap['XMR']));
+$exclMap = get_option('nmm_autopay_scan_incomplete', array());
+aok('failed addresses excluded from certification', is_array($exclMap) && isset($exclMap['XMR|xmr_aged']), 'excl=' . (is_array($exclMap) ? implode(',', array_keys($exclMap)) : '(scalar)'));
 NMM_Payment::cancel_expired_payments();
 aok('aged row survives a failed check',          rec_status($wpdb,$pt,$oAged) === 'unpaid', 'status=' . rec_status($wpdb,$pt,$oAged));
 
@@ -365,10 +366,58 @@ remove_filter('pre_http_request', $btcMock, 10);
 remove_all_filters('nmm_xmr_account_transactions');
 
 $covMap = get_option('nmm_autopay_scan_covered_at', array());
-aok('healthy coin stamped while other coin fails', is_array($covMap) && isset($covMap['BTC']) && !isset($covMap['XMR']), 'map=' . print_r($covMap, true));
+$exclMap = get_option('nmm_autopay_scan_incomplete', array());
+aok('healthy coin stamped while other coin fails', is_array($covMap) && isset($covMap['BTC']), 'map=' . (is_array($covMap) ? implode(',', array_keys($covMap)) : '(scalar)'));
+aok('failing coin address excluded',               is_array($exclMap) && isset($exclMap['XMR|xmr_aged2']), 'excl=' . (is_array($exclMap) ? implode(',', array_keys($exclMap)) : '(scalar)'));
 NMM_Payment::cancel_expired_payments();
 aok('healthy coin: aged row expires normally',    rec_status($wpdb,$pt,$oBtcAged) === 'cancelled', 'status=' . rec_status($wpdb,$pt,$oBtcAged));
 aok('failing coin: aged row stays protected',     rec_status($wpdb,$pt,$oXmrAged) === 'unpaid', 'status=' . rec_status($wpdb,$pt,$oXmrAged));
+
+// Address-level granularity: a permanently busy (dusted) address must defer
+// only ITS OWN rows - the coin's other aged orders still expire normally.
+// This is the whole-coin-freeze regression: previously one dusted carousel
+// address marked BTC dirty on every sweep and NO BTC order ever auto-cancelled.
+$wpdb->query("DELETE FROM `$pt`");
+delete_option('nmm_autopay_scan_cursor');
+delete_option('nmm_autopay_scan_retry');
+delete_option('nmm_autopay_scan_covered_at');
+delete_option('nmm_autopay_scan_dirty');
+delete_option('nmm_autopay_scan_incomplete');
+delete_option('nmm_autopay_scan_incomplete_next');
+delete_option('nmm_autopay_scan_sweep_start');
+$oBusy = mkorder('pending');
+$oQuiet = mkorder('pending');
+$agedTime2 = time() - 3 * 24 * 3600;
+$wpdb->query($wpdb->prepare(
+	"INSERT INTO `$pt` (address,cryptocurrency,status,ordered_at,order_id,order_amount,hd_address)
+	 VALUES ('btc_busy','BTC','unpaid',%d,%d,'0.00100000',0), ('btc_quiet','BTC','unpaid',%d,%d,'0.00200000',0)",
+	$agedTime2, $oBusy, $agedTime2, $oQuiet));
+
+$btcAddrMock = function ($pre, $args, $url) {
+	if (strpos($url, 'mempool.space/api/blocks/tip/height') !== false) {
+		return array('response' => array('code' => 200), 'body' => '105', 'headers' => array(), 'cookies' => array());
+	}
+	if (strpos($url, 'mempool.space/api/address/btc_busy') !== false) {
+		// permanently full page of recent unrelated activity (dusting)
+		$txs = array();
+		for ($i = 0; $i < 25; $i++) {
+			$txs[] = array('txid' => sprintf('busy_%02d', $i), 'status' => array('confirmed' => true, 'block_height' => 100, 'block_time' => time() - 120 - $i), 'vout' => array(array('scriptpubkey_address' => 'someone_else', 'value' => 1000)));
+		}
+		return array('response' => array('code' => 200), 'body' => json_encode($txs), 'headers' => array(), 'cookies' => array());
+	}
+	if (strpos($url, 'mempool.space/api/address/btc_quiet') !== false) {
+		return array('response' => array('code' => 200), 'body' => '[]', 'headers' => array(), 'cookies' => array());
+	}
+	return $pre;
+};
+add_filter('pre_http_request', $btcAddrMock, 10, 3);
+NMM_Payment::check_all_addresses_for_matching_payment(3 * 3600); // one page: wrap
+remove_filter('pre_http_request', $btcAddrMock, 10);
+NMM_Payment::cancel_expired_payments();
+aok('quiet address: aged row expires normally',   rec_status($wpdb,$pt,$oQuiet) === 'cancelled', 'status=' . rec_status($wpdb,$pt,$oQuiet));
+aok('busy (dusted) address: its rows defer',      rec_status($wpdb,$pt,$oBusy) === 'unpaid', 'status=' . rec_status($wpdb,$pt,$oBusy));
+$covMap = get_option('nmm_autopay_scan_covered_at', array());
+aok('  coin stamp still advanced',                is_array($covMap) && isset($covMap['BTC']), 'map=' . (is_array($covMap) ? implode(',', array_keys($covMap)) : '(scalar)'));
 
 $wpdb->query("DELETE FROM `$pt`");
 delete_option('nmm_autopay_scan_cursor');
@@ -377,4 +426,6 @@ delete_option('nmm_autopay_scan_covered_at');
 delete_option('nmm_autopay_scan_last_run');
 delete_option('nmm_autopay_scan_sweep_start');
 delete_option('nmm_autopay_scan_dirty');
+delete_option('nmm_autopay_scan_incomplete');
+delete_option('nmm_autopay_scan_incomplete_next');
 echo $GLOBALS['ac_ok'] ? "\nAUTOPAY-CANCEL CHECKS PASSED\n" : "\nAUTOPAY-CANCEL CHECKS FAILED\n";

--- a/tests/test-autopay-scan.php
+++ b/tests/test-autopay-scan.php
@@ -23,6 +23,8 @@ delete_option('nmm_autopay_scan_last_run');
 delete_option('nmm_autopay_scan_covered_at');
 delete_option('nmm_autopay_scan_sweep_start');
 delete_option('nmm_autopay_scan_dirty');
+delete_option('nmm_autopay_scan_incomplete');
+delete_option('nmm_autopay_scan_incomplete_next');
 
 $GLOBALS['as_ok'] = true;
 function sok($label, $cond, $extra = '') { printf("%-56s %s%s\n", $label, $cond ? 'ok' : 'FAIL', $extra !== '' ? "  $extra" : ''); if (!$cond) { $GLOBALS['as_ok'] = false; } }
@@ -43,6 +45,13 @@ function as_tick($lifetime) {
 function as_cov() {
 	$m = get_option('nmm_autopay_scan_covered_at', array());
 	return (is_array($m) && isset($m['XMR'])) ? (int) $m['XMR'] : 0;
+}
+
+// Whether "crypto|address" is in the ACTIVE per-address exclusion set that
+// cancel_expired_payments() consults (promoted from the builder at each wrap).
+function as_excluded($key) {
+	$m = get_option('nmm_autopay_scan_incomplete', array());
+	return is_array($m) && isset($m[$key]);
 }
 
 // scan_plan (pure): budget/window sizing. Small store stays at baseline with the
@@ -303,9 +312,11 @@ $retryNow = get_option('nmm_autopay_scan_retry', array());
 $goneKey = $retryNow[0]; // e.g. 'XMR|xmrf_0'
 $goneParts = explode('|', $goneKey, 2);
 $wpdb->query($wpdb->prepare("DELETE FROM `$pt` WHERE address=%s", $goneParts[1])); // as if paid/removed
-as_tick(3 * 3600); // still failing fetches; this tick wraps past the list end
+as_tick(3 * 3600); // still failing fetches
 sok('stale retry key dropped once not unpaid',  !in_array($goneKey, get_option('nmm_autopay_scan_retry', array()), true), 'gone=' . $goneKey);
-sok('no coverage stamp while fetches fail',     as_cov() === 0);
+as_tick(3 * 3600); // wraps past the list end, still failing
+sok('failing addresses excluded at the wrap',   as_excluded('XMR|xmrf_1'), 'excl=' . implode(',', array_keys(get_option('nmm_autopay_scan_incomplete', array()))));
+sok('coin still stamps despite failing addrs',  as_cov() > 0);
 
 // Once fetches succeed again, the retry set drains.
 remove_all_filters('nmm_xmr_account_transactions');
@@ -316,6 +327,7 @@ sok('retry set drains after fetches succeed',    count(get_option('nmm_autopay_s
 // A few more clean ticks guarantee a failure-free wrap, which may stamp again.
 for ($t = 0; $t < 4; $t++) { as_tick(3 * 3600); }
 sok('coverage resumes once fetches succeed',     as_cov() > 0);
+sok('exclusions drain once fetches succeed',     !as_excluded('XMR|xmrf_1'), 'excl=' . implode(',', array_keys(get_option('nmm_autopay_scan_incomplete', array()))));
 
 // --- coverage stamp semantics: sweep START time, and stale-cursor wraps ----
 // The stamp must be the completed sweep's start, not its wrap time: a row
@@ -365,6 +377,8 @@ delete_option('nmm_autopay_scan_cursor');
 delete_option('nmm_autopay_scan_retry');
 delete_option('nmm_autopay_scan_covered_at');
 delete_option('nmm_autopay_scan_dirty');
+delete_option('nmm_autopay_scan_incomplete');
+delete_option('nmm_autopay_scan_incomplete_next');
 for ($i = 0; $i < 9; $i++) {
 	$wpdb->query($wpdb->prepare("INSERT INTO `$pt` (address,cryptocurrency,status,ordered_at,order_id,order_amount,hd_address) VALUES (%s,'XMR','unpaid',%d,%d,'0.00100000',0)", sprintf('xmrd_%d', $i), time() - 2 * HOUR_IN_SECONDS, 770000 + $i));
 }
@@ -375,11 +389,13 @@ add_filter('nmm_xmr_account_transactions', function () { return array('result' =
 as_tick(3 * 3600); // recovery: retries 0,1 + sweep 3,4,5 all clean
 as_tick(3 * 3600); // 6,7,8 - end of list
 as_tick(3 * 3600); // wraps clean, but xmrd_2 was dropped unverified -> no stamp
-sok('dropped failure blocks the recovery wrap',   as_cov() === 0, 'covered=' . as_cov());
+sok('dropped failure excluded at recovery wrap',  as_excluded('XMR|xmrd_2'), 'excl=' . implode(',', array_keys(get_option('nmm_autopay_scan_incomplete', array()))));
+sok('coin still stamps at the recovery wrap',     as_cov() > 0, 'covered=' . as_cov());
 as_tick(3 * 3600); // fresh sweep re-visits everything: 3,4,5
 as_tick(3 * 3600); // 6,7,8
 as_tick(3 * 3600); // wraps - genuinely clean now
 sok('next fully-clean sweep stamps coverage',     as_cov() > 0, 'covered=' . as_cov());
+sok('clean sweep clears the dropped exclusion',   !as_excluded('XMR|xmrd_2'), 'excl=' . implode(',', array_keys(get_option('nmm_autopay_scan_incomplete', array()))));
 remove_all_filters('nmm_autopay_scan_retry_cap');
 
 // --- partial Solana history sweep must not certify coverage ----------------
@@ -430,6 +446,8 @@ delete_option('nmm_autopay_scan_cursor');
 delete_option('nmm_autopay_scan_retry');
 delete_option('nmm_autopay_scan_covered_at');
 delete_option('nmm_autopay_scan_dirty');
+delete_option('nmm_autopay_scan_incomplete');
+delete_option('nmm_autopay_scan_incomplete_next');
 delete_transient('nmm_sol_cursor_' . md5($solAddr));
 $wpdb->query($wpdb->prepare("INSERT INTO `$pt` (address,cryptocurrency,status,ordered_at,order_id,order_amount,hd_address) VALUES (%s,'SOL','unpaid',%d,%d,'0.10000000',0)", $solAddr, time() - 2 * HOUR_IN_SECONDS, 780000));
 // 30 in-window signatures > the 25-per-tick inspection budget -> partial pass.
@@ -437,7 +455,8 @@ for ($i = 0; $i < 30; $i++) { $GLOBALS['scov_sigs'][] = array('signature' => spr
 
 as_tick(3 * 3600); // single-page backlog: wrap-equivalent, but SOL is partial
 $covMapSol = get_option('nmm_autopay_scan_covered_at', array());
-sok('partial SOL sweep does not certify coverage', !is_array($covMapSol) || !isset($covMapSol['SOL']), 'map=' . (is_array($covMapSol) ? implode(',', array_keys($covMapSol)) : '(scalar)'));
+sok('partial SOL sweep excludes the address',      as_excluded('SOL|' . $solAddr), 'excl=' . implode(',', array_keys(get_option('nmm_autopay_scan_incomplete', array()))));
+sok('partial SOL sweep still stamps the coin',     is_array($covMapSol) && isset($covMapSol['SOL']), 'map=' . (is_array($covMapSol) ? implode(',', array_keys($covMapSol)) : '(scalar)'));
 
 as_tick(3 * 3600); // remaining 5 signatures: internal sweep completes mid-tick
 $covMapSol = get_option('nmm_autopay_scan_covered_at', array());
@@ -450,6 +469,8 @@ sok('completed SOL sweep certifies coverage',      is_array($covMapSol) && isset
 // so the sweep is incomplete and must NOT certify SOL coverage.
 delete_option('nmm_autopay_scan_covered_at');
 delete_option('nmm_autopay_scan_dirty');
+delete_option('nmm_autopay_scan_incomplete');
+delete_option('nmm_autopay_scan_incomplete_next');
 $srt = $wpdb->prefix . NMM_SOL_RETRY_TABLE;
 $wpdb->query($wpdb->prepare("DELETE FROM `$srt` WHERE address=%s", $solAddr));
 $wpdb->query($wpdb->prepare("INSERT INTO `$srt` (address, signature, first_failed_at, attempts, next_retry_at, block_time) VALUES (%s,'screc_sig',%d,1,%d,%d)", $solAddr, time() - 300, time() - 10, time() - 300));
@@ -457,7 +478,7 @@ $GLOBALS['scov_sigs_fail'] = true;
 $GLOBALS['scov_tx_credit'] = 5; // recovered, but nowhere near the order amount
 as_tick(3 * 3600);
 $covMapSol = get_option('nmm_autopay_scan_covered_at', array());
-sok('recovered retry + failed page never certifies', !is_array($covMapSol) || !isset($covMapSol['SOL']), 'map=' . (is_array($covMapSol) ? implode(',', array_keys($covMapSol)) : '(scalar)'));
+sok('recovered retry + failed page excludes addr',   as_excluded('SOL|' . $solAddr), 'excl=' . implode(',', array_keys(get_option('nmm_autopay_scan_incomplete', array()))));
 $GLOBALS['scov_sigs_fail'] = false;
 $GLOBALS['scov_tx_credit'] = 0;
 $wpdb->query($wpdb->prepare("DELETE FROM `$srt` WHERE address=%s", $solAddr));
@@ -506,24 +527,29 @@ delete_option('nmm_autopay_scan_cursor');
 delete_option('nmm_autopay_scan_retry');
 delete_option('nmm_autopay_scan_covered_at');
 delete_option('nmm_autopay_scan_dirty');
+delete_option('nmm_autopay_scan_incomplete');
+delete_option('nmm_autopay_scan_incomplete_next');
 $wpdb->query($wpdb->prepare("INSERT INTO `$pt` (address,cryptocurrency,status,ordered_at,order_id,order_amount,hd_address) VALUES ('btctrunc_addr','BTC','unpaid',%d,%d,'0.00100000',0)", time() - 2 * HOUR_IN_SECONDS, 785000));
 
 $GLOBALS['btr_txs'] = $btrPage(25, 1800); // FULL page, oldest entry well inside the window
 as_tick(3 * 3600);
 $covMapB = get_option('nmm_autopay_scan_covered_at', array());
-sok('full in-window page does not certify',        !is_array($covMapB) || !isset($covMapB['BTC']), 'map=' . (is_array($covMapB) ? implode(',', array_keys($covMapB)) : '(scalar)'));
+sok('full in-window page excludes the address',    as_excluded('BTC|btctrunc_addr'), 'excl=' . implode(',', array_keys(get_option('nmm_autopay_scan_incomplete', array()))));
+sok('full in-window page still stamps the coin',   is_array($covMapB) && isset($covMapB['BTC']), 'map=' . (is_array($covMapB) ? implode(',', array_keys($covMapB)) : '(scalar)'));
 
 $GLOBALS['btr_txs'] = $btrPage(25, 10 * 24 * 3600); // full page reaching PAST the window
 delete_option('nmm_autopay_scan_dirty');
+delete_option('nmm_autopay_scan_incomplete');
+delete_option('nmm_autopay_scan_incomplete_next');
 as_tick(3 * 3600);
 $covMapB = get_option('nmm_autopay_scan_covered_at', array());
-sok('page spanning past the window certifies',     is_array($covMapB) && isset($covMapB['BTC']), 'map=' . (is_array($covMapB) ? implode(',', array_keys($covMapB)) : '(scalar)'));
+sok('page spanning past the window certifies',     is_array($covMapB) && isset($covMapB['BTC']) && !as_excluded('BTC|btctrunc_addr'), 'map=' . (is_array($covMapB) ? implode(',', array_keys($covMapB)) : '(scalar)'));
 
 $GLOBALS['btr_txs'] = $btrPage(3, 1800); // short page: nothing below it
 delete_option('nmm_autopay_scan_covered_at');
 as_tick(3 * 3600);
 $covMapB = get_option('nmm_autopay_scan_covered_at', array());
-sok('short page certifies',                        is_array($covMapB) && isset($covMapB['BTC']), 'map=' . (is_array($covMapB) ? implode(',', array_keys($covMapB)) : '(scalar)'));
+sok('short page certifies',                        is_array($covMapB) && isset($covMapB['BTC']) && !as_excluded('BTC|btctrunc_addr'), 'map=' . (is_array($covMapB) ? implode(',', array_keys($covMapB)) : '(scalar)'));
 
 // Mixed directions: fullness must be judged on the RAW page, not the
 // incoming-filtered result. 25 raw in-window entries of which only ONE pays
@@ -534,9 +560,11 @@ for ($i = 1; $i < 25; $i++) { $btrMixed[$i]['vout'] = array(array('scriptpubkey_
 $GLOBALS['btr_txs'] = $btrMixed;
 delete_option('nmm_autopay_scan_covered_at');
 delete_option('nmm_autopay_scan_dirty');
+delete_option('nmm_autopay_scan_incomplete');
+delete_option('nmm_autopay_scan_incomplete_next');
 as_tick(3 * 3600);
 $covMapB = get_option('nmm_autopay_scan_covered_at', array());
-sok('full raw page, one incoming: not certified',  !is_array($covMapB) || !isset($covMapB['BTC']), 'map=' . (is_array($covMapB) ? implode(',', array_keys($covMapB)) : '(scalar)'));
+sok('full raw page, one incoming: addr excluded',  as_excluded('BTC|btctrunc_addr'), 'excl=' . implode(',', array_keys(get_option('nmm_autopay_scan_incomplete', array()))));
 remove_filter('pre_http_request', $btcMockTrunc, 10);
 delete_option('nmmpro_BTC_transactions_consumed_for_btctrunc_addr');
 
@@ -564,10 +592,12 @@ delete_option('nmm_autopay_scan_cursor');
 delete_option('nmm_autopay_scan_retry');
 delete_option('nmm_autopay_scan_covered_at');
 delete_option('nmm_autopay_scan_dirty');
+delete_option('nmm_autopay_scan_incomplete');
+delete_option('nmm_autopay_scan_incomplete_next');
 $wpdb->query($wpdb->prepare("INSERT INTO `$pt` (address,cryptocurrency,status,ordered_at,order_id,order_amount,hd_address) VALUES ('blk_cov_addr','BLK','unpaid',%d,%d,'0.00100000',0)", time() - 2 * HOUR_IN_SECONDS, 795000));
 as_tick(3 * 3600);
 $covMapK = get_option('nmm_autopay_scan_covered_at', array());
-sok('truncated detail body does not certify',      !is_array($covMapK) || !isset($covMapK['BLK']), 'map=' . (is_array($covMapK) ? implode(',', array_keys($covMapK)) : '(scalar)'));
+sok('truncated detail body excludes the address',  as_excluded('BLK|blk_cov_addr'), 'excl=' . implode(',', array_keys(get_option('nmm_autopay_scan_incomplete', array()))));
 sok('truncated detail body goes to the retry set', in_array('BLK|blk_cov_addr', get_option('nmm_autopay_scan_retry', array()), true), 'retry=' . implode(',', get_option('nmm_autopay_scan_retry', array())));
 
 // Malformed output entries must be just as uninspectable: a nonnumeric value
@@ -576,32 +606,126 @@ sok('truncated detail body goes to the retry set', in_array('BLK|blk_cov_addr', 
 $GLOBALS['blk_tx_body'] = array('vout' => array(array('value' => 'garbage', 'scriptPubKey' => array('addresses' => array('someone_else')))));
 delete_option('nmm_autopay_scan_covered_at');
 delete_option('nmm_autopay_scan_dirty');
+delete_option('nmm_autopay_scan_incomplete');
+delete_option('nmm_autopay_scan_incomplete_next');
 as_tick(3 * 3600);
 $covMapK = get_option('nmm_autopay_scan_covered_at', array());
-sok('nonnumeric output value does not certify',    !is_array($covMapK) || !isset($covMapK['BLK']), 'map=' . (is_array($covMapK) ? implode(',', array_keys($covMapK)) : '(scalar)'));
+sok('nonnumeric output value excludes the addr',   as_excluded('BLK|blk_cov_addr'), 'excl=' . implode(',', array_keys(get_option('nmm_autopay_scan_incomplete', array()))));
 
 $GLOBALS['blk_tx_body'] = array('vout' => array(array('value' => 1.0, 'scriptPubKey' => array('addresses' => array('')))));
 delete_option('nmm_autopay_scan_covered_at');
 delete_option('nmm_autopay_scan_dirty');
+delete_option('nmm_autopay_scan_incomplete');
+delete_option('nmm_autopay_scan_incomplete_next');
 as_tick(3 * 3600);
 $covMapK = get_option('nmm_autopay_scan_covered_at', array());
-sok('blank-string address does not certify',       !is_array($covMapK) || !isset($covMapK['BLK']), 'map=' . (is_array($covMapK) ? implode(',', array_keys($covMapK)) : '(scalar)'));
+sok('blank-string address excludes the addr',      as_excluded('BLK|blk_cov_addr'), 'excl=' . implode(',', array_keys(get_option('nmm_autopay_scan_incomplete', array()))));
 
 // A genuine OP_RETURN-class output (numeric zero, NO address list) is a
 // conclusive non-payment and must not block certification.
 $GLOBALS['blk_tx_body'] = array('vout' => array(array('value' => 0)));
 delete_option('nmm_autopay_scan_covered_at');
 delete_option('nmm_autopay_scan_dirty');
+delete_option('nmm_autopay_scan_incomplete');
+delete_option('nmm_autopay_scan_incomplete_next');
 as_tick(3 * 3600);
 $covMapK = get_option('nmm_autopay_scan_covered_at', array());
-sok('zero-value addressless output still certifies', is_array($covMapK) && isset($covMapK['BLK']), 'map=' . (is_array($covMapK) ? implode(',', array_keys($covMapK)) : '(scalar)'));
+sok('zero-value addressless output still certifies', is_array($covMapK) && isset($covMapK['BLK']) && !as_excluded('BLK|blk_cov_addr'), 'map=' . (is_array($covMapK) ? implode(',', array_keys($covMapK)) : '(scalar)'));
 
 $GLOBALS['blk_tx_body'] = array('vout' => array(array('value' => 1.0, 'scriptPubKey' => array('addresses' => array('someone_else')))), 'confirmations' => 100, 'time' => time() - 600, 'txid' => 'blk_tx1');
 delete_option('nmm_autopay_scan_covered_at');
 as_tick(3 * 3600);
 $covMapK = get_option('nmm_autopay_scan_covered_at', array());
-sok('well-formed detail body certifies',           is_array($covMapK) && isset($covMapK['BLK']), 'map=' . (is_array($covMapK) ? implode(',', array_keys($covMapK)) : '(scalar)'));
+sok('well-formed detail body certifies',           is_array($covMapK) && isset($covMapK['BLK']) && !as_excluded('BLK|blk_cov_addr'), 'map=' . (is_array($covMapK) ? implode(',', array_keys($covMapK)) : '(scalar)'));
 remove_filter('pre_http_request', $blkMock, 10);
+
+// A malformed TOP-LEVEL body (json null) previously threw a TypeError through
+// property_exists() that escaped the \Exception-only fetch boundary and killed
+// the whole cron run before cursor/retry state persisted. It must now be an
+// ordinary fetch failure: the tick completes and the address is retried.
+$blkNullMock = function ($pre, $args, $url) {
+	if (strpos($url, 'explorer.blackcoin.nl/ext/getaddress/') !== false) {
+		return array('response' => array('code' => 200), 'body' => 'null', 'headers' => array(), 'cookies' => array());
+	}
+	return $pre;
+};
+add_filter('pre_http_request', $blkNullMock, 10, 3);
+delete_option('nmm_autopay_scan_retry');
+as_tick(3 * 3600); // must not fatal
+sok('null top-level body survives as a retry',     in_array('BLK|blk_cov_addr', get_option('nmm_autopay_scan_retry', array()), true), 'retry=' . implode(',', get_option('nmm_autopay_scan_retry', array())));
+remove_filter('pre_http_request', $blkNullMock, 10);
+
+// --- bulk-detail accounting: every requested hash must come back ------------
+// Koios (ADA) and WhatsOnChain (BSV) are asked for details of a LIST of tx
+// hashes and can answer HTTP 200 with an empty or partial set. A transaction
+// missing from the bulk response was not inspected: treating it as "no
+// payment" would let a short address page certify coverage over an unverified
+// payment. The visit must fail (retry) until the response accounts for every
+// requested hash.
+$GLOBALS['ada_bulk_partial'] = true;
+$adaMock = function ($pre, $args, $url) {
+	if (strpos($url, 'api.koios.rest/api/v1/address_txs') !== false) {
+		return array('response' => array('code' => 200), 'body' => json_encode(array(
+			array('tx_hash' => 'ada_t1', 'block_time' => time() - 600),
+			array('tx_hash' => 'ada_t2', 'block_time' => time() - 700),
+		)), 'headers' => array(), 'cookies' => array());
+	}
+	if (strpos($url, 'api.koios.rest/api/v1/tx_utxos') !== false) {
+		$rows = array(array('tx_hash' => 'ada_t1', 'outputs' => array(array('payment_addr' => array('bech32' => 'someone_else'), 'value' => '1000'))));
+		if (!$GLOBALS['ada_bulk_partial']) {
+			$rows[] = array('tx_hash' => 'ada_t2', 'outputs' => array(array('payment_addr' => array('bech32' => 'someone_else'), 'value' => '1000')));
+		}
+		return array('response' => array('code' => 200), 'body' => json_encode($rows), 'headers' => array(), 'cookies' => array());
+	}
+	return $pre;
+};
+add_filter('pre_http_request', $adaMock, 10, 3);
+$wpdb->query("DELETE FROM `$pt`");
+delete_option('nmm_autopay_scan_cursor');
+delete_option('nmm_autopay_scan_retry');
+delete_option('nmm_autopay_scan_covered_at');
+delete_option('nmm_autopay_scan_dirty');
+delete_option('nmm_autopay_scan_incomplete');
+delete_option('nmm_autopay_scan_incomplete_next');
+$wpdb->query($wpdb->prepare("INSERT INTO `$pt` (address,cryptocurrency,status,ordered_at,order_id,order_amount,hd_address) VALUES ('ada_cov_addr','ADA','unpaid',%d,%d,'0.00100000',0)", time() - 2 * HOUR_IN_SECONDS, 796000));
+as_tick(3 * 3600); // bulk response missing ada_t2 -> visit fails
+sok('partial ADA bulk response goes to retry',     in_array('ADA|ada_cov_addr', get_option('nmm_autopay_scan_retry', array()), true), 'retry=' . implode(',', get_option('nmm_autopay_scan_retry', array())));
+sok('partial ADA bulk response excluded',          as_excluded('ADA|ada_cov_addr'), 'excl=' . implode(',', array_keys(get_option('nmm_autopay_scan_incomplete', array()))));
+$GLOBALS['ada_bulk_partial'] = false;
+as_tick(3 * 3600); // complete response: retry succeeds, next wrap certifies
+$covMapA = get_option('nmm_autopay_scan_covered_at', array());
+sok('complete ADA bulk response certifies',        is_array($covMapA) && isset($covMapA['ADA']) && !as_excluded('ADA|ada_cov_addr'), 'map=' . (is_array($covMapA) ? implode(',', array_keys($covMapA)) : '(scalar)'));
+remove_filter('pre_http_request', $adaMock, 10);
+
+$GLOBALS['bsv_bulk_partial'] = true;
+$bsvMock = function ($pre, $args, $url) {
+	if (strpos($url, 'api.whatsonchain.com/v1/bsv/main/address/') !== false) {
+		return array('response' => array('code' => 200), 'body' => json_encode(array(array('tx_hash' => 'bsv_t1', 'height' => 100))), 'headers' => array(), 'cookies' => array());
+	}
+	if (strpos($url, 'api.whatsonchain.com/v1/bsv/main/chain/info') !== false) {
+		return array('response' => array('code' => 200), 'body' => json_encode(array('blocks' => 105)), 'headers' => array(), 'cookies' => array());
+	}
+	if (strpos($url, 'api.whatsonchain.com/v1/bsv/main/txs') !== false) {
+		$rows = $GLOBALS['bsv_bulk_partial'] ? array() : array(array('txid' => 'bsv_t1', 'time' => time() - 600, 'vout' => array(array('value' => 0.5, 'scriptPubKey' => array('addresses' => array('someone_else'))))));
+		return array('response' => array('code' => 200), 'body' => json_encode($rows), 'headers' => array(), 'cookies' => array());
+	}
+	return $pre;
+};
+add_filter('pre_http_request', $bsvMock, 10, 3);
+$wpdb->query("DELETE FROM `$pt`");
+delete_option('nmm_autopay_scan_cursor');
+delete_option('nmm_autopay_scan_retry');
+delete_option('nmm_autopay_scan_covered_at');
+delete_option('nmm_autopay_scan_incomplete');
+delete_option('nmm_autopay_scan_incomplete_next');
+$wpdb->query($wpdb->prepare("INSERT INTO `$pt` (address,cryptocurrency,status,ordered_at,order_id,order_amount,hd_address) VALUES ('bsv_cov_addr','BSV','unpaid',%d,%d,'0.00100000',0)", time() - 2 * HOUR_IN_SECONDS, 797000));
+as_tick(3 * 3600); // empty bulk response for a non-empty request -> visit fails
+sok('partial BSV bulk response goes to retry',     in_array('BSV|bsv_cov_addr', get_option('nmm_autopay_scan_retry', array()), true), 'retry=' . implode(',', get_option('nmm_autopay_scan_retry', array())));
+$GLOBALS['bsv_bulk_partial'] = false;
+as_tick(3 * 3600);
+$covMapV = get_option('nmm_autopay_scan_covered_at', array());
+sok('complete BSV bulk response certifies',        is_array($covMapV) && isset($covMapV['BSV']) && !as_excluded('BSV|bsv_cov_addr'), 'map=' . (is_array($covMapV) ? implode(',', array_keys($covMapV)) : '(scalar)'));
+remove_filter('pre_http_request', $bsvMock, 10);
 
 // --- unknown ticker: cannot be verified, must never be certified -----------
 // A row whose coin was removed from the registry is skipped by the scan; it
@@ -612,6 +736,8 @@ delete_option('nmm_autopay_scan_cursor');
 delete_option('nmm_autopay_scan_retry');
 delete_option('nmm_autopay_scan_covered_at');
 delete_option('nmm_autopay_scan_dirty');
+delete_option('nmm_autopay_scan_incomplete');
+delete_option('nmm_autopay_scan_incomplete_next');
 $wpdb->query($wpdb->prepare("INSERT INTO `$pt` (address,cryptocurrency,status,ordered_at,order_id,order_amount,hd_address) VALUES ('zombie_addr','ZZZFAKE','unpaid',%d,%d,'0.00100000',0)", time() - 2 * HOUR_IN_SECONDS, 790000));
 as_tick(3 * 3600);
 $covMapZ = get_option('nmm_autopay_scan_covered_at', array());
@@ -673,5 +799,7 @@ delete_option('nmm_autopay_scan_last_run');
 delete_option('nmm_autopay_scan_covered_at');
 delete_option('nmm_autopay_scan_sweep_start');
 delete_option('nmm_autopay_scan_dirty');
+delete_option('nmm_autopay_scan_incomplete');
+delete_option('nmm_autopay_scan_incomplete_next');
 
 echo $GLOBALS['as_ok'] ? "\nAUTOPAY-SCAN CHECKS PASSED\n" : "\nAUTOPAY-SCAN CHECKS FAILED\n";


### PR DESCRIPTION
Fixes the three post-release review findings on v2.9.6.

**[P1] Bulk detail lookups accept partial replies (ADA, BSV).** Koios `tx_utxos` and WhatsOnChain bulk `txs` can answer HTTP 200 with an empty or partial set; a transaction missing from the reply was never inspected, yet the visit looked like a successful empty check and could certify coverage. Both adapters now account for every requested hash — missing or malformed rows fail the visit into the retry path.

**[P1] One busy address could freeze a whole currency's expiry.** A permanently full fixed-depth page (e.g. a dusted carousel address with 25+ in-window transactions) marked its coin dirty on every sweep, so *no* order of that currency ever auto-cancelled. Completeness is now tracked **per address**: incomplete addresses (truncated pages, mid-window Solana sweeps, dropped retries) accumulate in a capped builder set (`nmm_autopay_scan_incomplete_next`, 500 keys; overflow falls back to coin-level dirty) promoted at each wrap — together with still-failing retry keys — to the active exclusion set (`nmm_autopay_scan_incomplete`) that `cancel_expired_payments()` consults. Only the excluded address's rows defer; the coin's stamp advances and every other order expires normally. Only an unverifiable (deregistered) ticker still blocks a whole coin.

**[P2] Malformed HTTP-200 bodies could abort the cron mid-sweep.** Adapter parsing can throw `TypeError`/`Error` on PHP 8 (BLK/ONION called `property_exists()` on an unchecked decode); the throw escaped the `\Exception`-only fetch boundary before cursor/retry state persisted, so one bad address repeatedly killed every run. The boundary now catches `\Throwable` (a throw is an ordinary failed fetch → retry) and the Iquidus top-level decodes are validated.

## Verification
- New tests: dusted-address granularity (quiet aged BTC row cancels while the dusted address's row defers and the stamp advances), partial/complete ADA and BSV bulk responses, null top-level body survives as a retry, and all exclusion-set lifecycle assertions (promotion at wrap, drain on clean sweep, drop/SOL/truncation routing).
- All four DB suites pass in a real WordPress+MariaDB in CI order; offline suites and repo-wide `php -l` clean.
- Codex explicit verdict: **READY TO MERGE** (first round).

Awaiting Ross's review before merge/tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)